### PR TITLE
Adds Trace Context Propagation Formatters

### DIFF
--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -14,6 +14,7 @@
 
 require "opencensus/trace/config"
 require "opencensus/trace/exporters"
+require "opencensus/trace/formatters"
 require "opencensus/trace/integrations"
 require "opencensus/trace/samplers"
 require "opencensus/trace/span"

--- a/lib/opencensus/trace/formatters.rb
+++ b/lib/opencensus/trace/formatters.rb
@@ -1,0 +1,26 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "opencensus/trace/formatters/binary"
+require "opencensus/trace/formatters/cloud_trace"
+require "opencensus/trace/formatters/trace_context"
+
+module OpenCensus
+  module Trace
+    module Formatters
+      DEFAULT = CloudTrace.new
+      TraceContextData = Struct.new :trace_id, :span_id, :trace_options
+    end
+  end
+end

--- a/lib/opencensus/trace/formatters.rb
+++ b/lib/opencensus/trace/formatters.rb
@@ -19,7 +19,9 @@ require "opencensus/trace/formatters/trace_context"
 module OpenCensus
   module Trace
     module Formatters
-      DEFAULT = CloudTrace.new
+      DEFAULT = TraceContext.new
+
+      ## @private Internal struct that holds parsed trace context data.
       TraceContextData = Struct.new :trace_id, :span_id, :trace_options
     end
   end

--- a/lib/opencensus/trace/formatters.rb
+++ b/lib/opencensus/trace/formatters.rb
@@ -19,6 +19,7 @@ require "opencensus/trace/formatters/trace_context"
 module OpenCensus
   module Trace
     module Formatters
+      ## The default context formatter
       DEFAULT = TraceContext.new
 
       ## @private Internal struct that holds parsed trace context data.

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -21,7 +21,7 @@ module OpenCensus
       # [documentation](https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md).
       #
       class Binary
-        BINARY_FORMAT = "CCH32CH16CC"
+        BINARY_FORMAT = "CCH32CH16CC".freeze
         ##
         # Deserialize a trace context header into a TraceContext object.
         #
@@ -30,7 +30,7 @@ module OpenCensus
         #
         def deserialize binary
           data = binary.unpack(BINARY_FORMAT)
-          if (data[0] == 0 && data[1] == 0 && data[3] == 1 && data[5] == 2)
+          if data[0].zero? && data[1].zero? && data[3] == 1 && data[5] == 2
             TraceContextData.new data[2], data[4], data[6]
           else
             nil

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -21,7 +21,9 @@ module OpenCensus
       # [documentation](https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md).
       #
       class Binary
+        ## @private Internal format used to (un)pack binary data
         BINARY_FORMAT = "CCH32CH16CC".freeze
+
         ##
         # Deserialize a trace context header into a TraceContext object.
         #

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -1,0 +1,60 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module OpenCensus
+  module Trace
+    module Formatters
+      ##
+      # This formatter serializes and deserializes span context according to
+      # the OpenCensus' BinaryEncoding specification. See
+      # [documentation](https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md).
+      #
+      class Binary
+        BINARY_FORMAT = "CCH32CH16CC"
+        ##
+        # Deserialize a trace context header into a TraceContext object.
+        #
+        # @param [String]
+        # @return [TraceContext, nil]
+        #
+        def deserialize binary
+          data = binary.unpack(BINARY_FORMAT)
+          if (data[0] == 0 && data[1] == 0 && data[3] == 1 && data[5] == 2)
+            TraceContextData.new data[2], data[4], data[6]
+          else
+            nil
+          end
+        end
+
+        ##
+        # Serialize a SpanContext object.
+        #
+        # @param [SpanContext]
+        # @return [String]
+        #
+        def serialize span_context
+          [
+            0, # version
+            0, # field 0
+            span_context.trace_id,
+            1, # field 1
+            span_context.span_id,
+            2, # field 2
+            span_context.trace_options
+          ].pack(BINARY_FORMAT)
+        end
+      end
+    end
+  end
+end

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -26,7 +26,7 @@ module OpenCensus
         # Deserialize a trace context header into a TraceContext object.
         #
         # @param [String]
-        # @return [TraceContext, nil]
+        # @return [TraceContextData, nil]
         #
         def deserialize binary
           data = binary.unpack(BINARY_FORMAT)

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -26,7 +26,7 @@ module OpenCensus
         # Deserialize a trace context header into a TraceContext object.
         #
         # @param [String]
-        # @return [TraceContext, nil]
+        # @return [TraceContextData, nil]
         #
         def deserialize header
           match = HEADER_FORMAT.match(header)

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -1,0 +1,57 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module OpenCensus
+  module Trace
+    module Formatters
+      ##
+      # This formatter serializes and deserializes span context according to
+      # the Google X-Cloud-Trace header specification.
+      #
+      class CloudTrace
+        HEADER_FORMAT = /([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?/
+
+        ##
+        # Deserialize a trace context header into a TraceContext object.
+        #
+        # @param [String]
+        # @return [TraceContext, nil]
+        #
+        def deserialize header
+          if match = HEADER_FORMAT.match(header)
+            trace_id = match[1]
+            span_id = sprintf("%016x", match[2].to_i)
+            trace_options = match[3].to_i
+            TraceContextData.new trace_id, span_id, trace_options
+          else
+            nil
+          end
+        end
+
+        ##
+        # Serialize a SpanContext object.
+        #
+        # @param [SpanContext]
+        # @return [String]
+        #
+        def serialize span_context
+          ret = span_context.trace_id
+          ret << '/' << span_context.span_id.to_i(16).to_s if span_context.span_id
+          ret << ';o=' << span_context.trace_options.to_s if span_context.trace_options
+          ret
+        end
+      end
+    end
+  end
+end

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -20,7 +20,7 @@ module OpenCensus
       # the Google X-Cloud-Trace header specification.
       #
       class CloudTrace
-        HEADER_FORMAT = /([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?/
+        HEADER_FORMAT = %r{([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?}
 
         ##
         # Deserialize a trace context header into a TraceContext object.
@@ -29,9 +29,10 @@ module OpenCensus
         # @return [TraceContext, nil]
         #
         def deserialize header
-          if match = HEADER_FORMAT.match(header)
+          match = HEADER_FORMAT.match(header)
+          if match
             trace_id = match[1]
-            span_id = sprintf("%016x", match[2].to_i)
+            span_id = format("%016x", match[2].to_i)
             trace_options = match[3].to_i
             TraceContextData.new trace_id, span_id, trace_options
           else
@@ -46,10 +47,14 @@ module OpenCensus
         # @return [String]
         #
         def serialize span_context
-          ret = span_context.trace_id
-          ret << '/' << span_context.span_id.to_i(16).to_s if span_context.span_id
-          ret << ';o=' << span_context.trace_options.to_s if span_context.trace_options
-          ret
+          span_context.trace_id.tap do |ret|
+            if span_context.span_id
+              ret << "/" << span_context.span_id.to_i(16).to_s
+            end
+            if span_context.trace_options
+              ret << ";o=" << span_context.trace_options.to_s
+            end
+          end
         end
       end
     end

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -20,6 +20,7 @@ module OpenCensus
       # the Google X-Cloud-Trace header specification.
       #
       class CloudTrace
+        ## @private Internal regex used to parse fields
         HEADER_FORMAT = %r{([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?}
 
         ##

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -1,0 +1,79 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module OpenCensus
+  module Trace
+    module Formatters
+      ##
+      # This formatter serializes and deserializes span context according to
+      # the TraceContext specification. See
+      # [documentation](https://github.com/TraceContext/tracecontext-spec/blob/master/trace_context/HTTP_HEADER_FORMAT.md).
+      #
+      class TraceContext
+        VERSION_PATTERN = /^([0-9a-fA-F]{2})-(.+)$/
+        HEADER_V0_PATTERN =
+          /^([0-9a-fA-F]{32})-([0-9a-fA-F]{16})(-([0-9a-fA-F]{2}))?$/
+
+        ##
+        # Deserialize a trace context header into a TraceContext object.
+        #
+        # @param [String]
+        # @return [TraceContext, nil]
+        #
+        def deserialize header
+          match = VERSION_PATTERN.match(header)
+          if match
+            version = match[1].to_i(16)
+            version_format = match[2]
+            case version
+            when 0
+              parse_trace_context_header_version_0 version_format
+            else
+              nil
+            end
+          else
+            nil
+          end
+        end
+
+        ##
+        # Serialize a SpanContext object.
+        #
+        # @param [SpanContext]
+        # @return [String]
+        #
+        def serialize span_context
+          sprintf(
+            "%02d-%s-%s-%02d",
+            0, # version 0
+            span_context.trace_id,
+            span_context.span_id,
+            span_context.trace_options
+          )
+        end
+
+        private
+
+        def parse_trace_context_header_version_0 str
+          match = HEADER_V0_PATTERN.match(str)
+          if match
+            TraceContextData.new match[1].downcase,
+                                 match[2].downcase,
+                                 match[4].to_i(16)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -21,7 +21,10 @@ module OpenCensus
       # [documentation](https://github.com/TraceContext/tracecontext-spec/blob/master/trace_context/HTTP_HEADER_FORMAT.md).
       #
       class TraceContext
+        ## @private Internal regex used to identify the TraceContext version
         VERSION_PATTERN = /^([0-9a-fA-F]{2})-(.+)$/
+
+        ## @private Internal regex used to parse fields in version 0
         HEADER_V0_PATTERN =
           /^([0-9a-fA-F]{32})-([0-9a-fA-F]{16})(-([0-9a-fA-F]{2}))?$/
 

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -54,12 +54,12 @@ module OpenCensus
         # @return [String]
         #
         def serialize span_context
-          sprintf(
-            "%02d-%s-%s-%02d",
-            0, # version 0
-            span_context.trace_id,
-            span_context.span_id,
-            span_context.trace_options
+          format(
+            "%02<version>d-%<trace_id>s-%<span_id>s-%02<trace_options>d",
+            version: 0, # version 0,
+            trace_id: span_context.trace_id,
+            span_id: span_context.span_id,
+            trace_options: span_context.trace_options
           )
         end
 

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -29,7 +29,7 @@ module OpenCensus
         # Deserialize a trace context header into a TraceContext object.
         #
         # @param [String]
-        # @return [TraceContext, nil]
+        # @return [TraceContextData, nil]
         #
         def deserialize header
           match = VERSION_PATTERN.match(header)

--- a/test/trace/formatters/binary_test.rb
+++ b/test/trace/formatters/binary_test.rb
@@ -1,0 +1,53 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+describe OpenCensus::Trace::Formatters::Binary do
+  let(:formatter) { OpenCensus::Trace::Formatters::Binary.new }
+
+  describe "deserialize" do
+    it "should return nil on invalid format" do
+      data = formatter.deserialize "badvalue"
+      data.must_be_nil
+    end
+
+    it "should parse a valid format" do
+      data = formatter.deserialize ["0000123456789012345678901234567890ab0100000000000004d20201"].pack("H*")
+      data.wont_be_nil
+      data.trace_id.must_equal "123456789012345678901234567890ab"
+      data.span_id.must_equal "00000000000004d2"
+      data.trace_options.must_equal 1
+    end
+  end
+
+  describe "serialize" do
+    let(:trace_data) do
+      OpenCensus::Trace::SpanContext::TraceData.new(
+        "123456789012345678901234567890ab",
+        1,
+        {},
+        {}
+      )
+    end
+    let(:span_context) do
+      OpenCensus::Trace::SpanContext.new trace_data, nil, "00000000000004d2"
+    end
+
+    it "should serialize a SpanContext object" do
+      header = formatter.serialize span_context
+      header.must_equal ["0000123456789012345678901234567890ab0100000000000004d20201"].pack("H*")
+    end
+  end
+end

--- a/test/trace/formatters/cloud_trace_test.rb
+++ b/test/trace/formatters/cloud_trace_test.rb
@@ -1,0 +1,53 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+describe OpenCensus::Trace::Formatters::CloudTrace do
+  let(:formatter) { OpenCensus::Trace::Formatters::CloudTrace.new }
+
+  describe "deserialize" do
+    it "should return nil on invalid format" do
+      data = formatter.deserialize "badvalue"
+      data.must_be_nil
+    end
+
+    it "should parse a valid format" do
+      data = formatter.deserialize "123456789012345678901234567890ab/1234;o=1"
+      data.wont_be_nil
+      data.trace_id.must_equal "123456789012345678901234567890ab"
+      data.span_id.must_equal "00000000000004d2"
+      data.trace_options.must_equal 1
+    end
+  end
+
+  describe "serialize" do
+    let(:trace_data) do
+      OpenCensus::Trace::SpanContext::TraceData.new(
+        "123456789012345678901234567890ab",
+        1,
+        {},
+        {}
+      )
+    end
+    let(:span_context) do
+      OpenCensus::Trace::SpanContext.new trace_data, nil, "00000000000004d2"
+    end
+
+    it "should serialize a SpanContext object" do
+      header = formatter.serialize span_context
+      header.must_equal "123456789012345678901234567890ab/1234;o=1"
+    end
+  end
+end

--- a/test/trace/formatters/trace_context_test.rb
+++ b/test/trace/formatters/trace_context_test.rb
@@ -1,0 +1,58 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+describe OpenCensus::Trace::Formatters::TraceContext do
+  let(:formatter) { OpenCensus::Trace::Formatters::TraceContext.new }
+
+  describe "deserialize" do
+    it "should return nil on invalid format" do
+      data = formatter.deserialize "badvalue"
+      data.must_be_nil
+    end
+
+    it "should return nil on unsupported version" do
+      data = formatter.deserialize "ff-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+      data.must_be_nil
+    end
+
+    it "should parse a valid format" do
+      data = formatter.deserialize "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+      data.wont_be_nil
+      data.trace_id.must_equal "0123456789abcdef0123456789abcdef"
+      data.span_id.must_equal "0123456789abcdef"
+      data.trace_options.must_equal 1
+    end
+  end
+
+  describe "serialize" do
+    let(:trace_data) do
+      OpenCensus::Trace::SpanContext::TraceData.new(
+        "0123456789abcdef0123456789abcdef",
+        1,
+        {},
+        {}
+      )
+    end
+    let(:span_context) do
+      OpenCensus::Trace::SpanContext.new trace_data, nil, "0123456789abcdef"
+    end
+
+    it "should serialize a SpanContext object" do
+      header = formatter.serialize span_context
+      header.must_equal "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    end
+  end
+end


### PR DESCRIPTION
Defines a formatter duck-type which implements serialize/deserialize on trace contexts.

Currently, you provide a `formatter` named option to `SpanContext.create_root`. The created SpanContext and its children will use the provided formatter to create the trace context header (which we can rename).