### PR TITLE
Make sampling decision up front when a span is created

### DIFF
--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -108,13 +108,17 @@ module OpenCensus
       # Will throw an exception if there is no current SpanContext.
       #
       # @param [String] name Name of the span
+      # @param [Sampler] sampler Span-scoped sampler. If not provided,
+      #     defaults to the trace configuration's default sampler.
+      #
       # @return [SpanBuilder] A SpanBuilder object that you can use to
       #     set span attributes and create children.
       #
-      def start_span name, skip_frames: 0
+      def start_span name, skip_frames: 0, sampler: nil
         context = span_context
         raise "No currently active span context" unless context
-        span = context.start_span name, skip_frames: skip_frames + 1
+        span = context.start_span name, skip_frames: skip_frames + 1,
+                                        sampler: sampler
         self.span_context = span.context
         span
       end
@@ -131,9 +135,11 @@ module OpenCensus
       # will create subspans.
       #
       # @param [String] name Name of the span
+      # @param [Sampler] sampler Span-scoped sampler. If not provided,
+      #     defaults to the trace configuration's default sampler.
       #
-      def in_span name, skip_frames: 0
-        span = start_span name, skip_frames: skip_frames + 1
+      def in_span name, skip_frames: 0, sampler: nil
+        span = start_span name, skip_frames: skip_frames + 1, sampler: sampler
         begin
           yield span
         ensure

--- a/lib/opencensus/trace/samplers/probability.rb
+++ b/lib/opencensus/trace/samplers/probability.rb
@@ -28,12 +28,13 @@ module OpenCensus
 
         def call opts = {}
           span_context = opts[:span_context]
-          value = if span_context
-                    (span_context.trace_id % 0x10000000000000000).to_f /
-                      0x10000000000000000
-                  else
-                    @rng.rand
-                  end
+          value =
+            if span_context
+              (span_context.trace_id.to_i(16) % 0x10000000000000000).to_f /
+                0x10000000000000000
+            else
+              @rng.rand
+            end
           value <= @rate
         end
       end

--- a/lib/opencensus/trace/samplers/probability.rb
+++ b/lib/opencensus/trace/samplers/probability.rb
@@ -30,8 +30,12 @@ module OpenCensus
           span_context = opts[:span_context]
           value =
             if span_context
-              (span_context.trace_id.to_i(16) % 0x10000000000000000).to_f /
-                0x10000000000000000
+              if span_context.sampled?
+                0.0
+              else
+                (span_context.trace_id.to_i(16) % 0x10000000000000000).to_f /
+                  0x10000000000000000
+              end
             else
               @rng.rand
             end

--- a/lib/opencensus/trace/samplers/probability.rb
+++ b/lib/opencensus/trace/samplers/probability.rb
@@ -28,14 +28,11 @@ module OpenCensus
 
         def call opts = {}
           span_context = opts[:span_context]
+          return true if span_context && span_context.sampled?
           value =
             if span_context
-              if span_context.sampled?
-                0.0
-              else
-                (span_context.trace_id.to_i(16) % 0x10000000000000000).to_f /
-                  0x10000000000000000
-              end
+              (span_context.trace_id.to_i(16) % 0x10000000000000000).to_f /
+                0x10000000000000000
             else
               @rng.rand
             end

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -77,13 +77,12 @@ module OpenCensus
       end
 
       ##
-      # Sampler for this span. Generally this field is set from the Trace
-      # configuration when the span is first created. However, you can also
-      # change it after the fact.
+      # Sampling decision for this span. Generally this field is set when the
+      # span is first created. However, you can also change it after the fact.
       #
-      # @return [Sampler]
+      # @return [boolean]
       #
-      attr_accessor :sampler
+      attr_accessor :sampled
 
       ##
       # A description of the span's operation.
@@ -276,9 +275,9 @@ module OpenCensus
       #
       # @private
       #
-      def initialize span_context, skip_frames: 0
+      def initialize span_context, sampled, skip_frames: 0
         @context = span_context
-        @sampler = OpenCensus::Trace::Samplers::DEFAULT
+        @sampled = sampled
         @name = ""
         @start_time = nil
         @end_time = nil

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -105,6 +105,21 @@ module OpenCensus
       attr_reader :span_id
 
       ##
+      # Whether the context (e.g. the parent span) has been sampled. This
+      # information may be used in sampling decisions for new spans.
+      #
+      # @return [boolean]
+      #
+      def sampled?
+        span = this_span
+        if span
+          span.sampled
+        else
+          trace_options & 0x01 != 0
+        end
+      end
+
+      ##
       # Generate and return a Trace-Context header value corresponding to
       # this context. This header may be passed as a Trace-Context to
       # downstream remote API calls.

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -116,6 +116,16 @@ describe OpenCensus::Trace::SpanContext do
       frame.label.must_match %r{^block}
       frame.path.must_match %r{span_context_test\.rb$}
     end
+
+    it "honors span-scoped sampler" do
+      span_context = OpenCensus::Trace::SpanContext.create_root
+      sampler = OpenCensus::Trace::Samplers::AlwaysSample.new
+      span = span_context.start_span "hello", sampler: sampler
+      span.sampled.must_equal true
+      sampler = OpenCensus::Trace::Samplers::NeverSample.new
+      span = span_context.start_span "hello", sampler: sampler
+      span.sampled.must_equal false
+    end
   end
 
   describe "in_span" do
@@ -136,6 +146,18 @@ describe OpenCensus::Trace::SpanContext do
         frame = span.instance_variable_get(:@stack_trace).first
         frame.label.must_match %r{^block}
         frame.path.must_match %r{span_context_test\.rb$}
+      end
+    end
+
+    it "honors span-scoped sampler" do
+      span_context = OpenCensus::Trace::SpanContext.create_root
+      sampler = OpenCensus::Trace::Samplers::AlwaysSample.new
+      span_context.in_span "hello", sampler: sampler do |span|
+        span.sampled.must_equal true
+      end
+      sampler = OpenCensus::Trace::Samplers::NeverSample.new
+      span_context.in_span "hello", sampler: sampler do |span|
+        span.sampled.must_equal false
       end
     end
   end


### PR DESCRIPTION
Previously I thought we could defer sampling decisions to the point when we export the entire trace, but now I realize sampling decisions have to happen up front because a static yea/nay decision must be propagated to remote spans. So now, call the sampler when a span is created, and require that span-scoped samplers be passed in at span creation.