### PR TITLE
Automatically Build Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+/docs/_site
+/docs/Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - "Rakefile"
     - "support/**/*"
     - "test/**/*"
+    - "docs/**/*"
 
 Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,12 @@ rvm:
 before_install: gem install bundler -v 1.15.1
 script:
   - bundle exec rake
+
+deploy:
+  provider: pages
+  local_dir: docs
+  skip_cleanup: true
+  email: chingor@google.com # To satisfy the CLA check, replace this with bot email.
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: master

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
+require "yard"
 
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
@@ -10,4 +11,10 @@ Rake::TestTask.new :test do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task :default => [:test, :rubocop]
+YARD::Rake::YardocTask.new do |t|
+ t.files   = ['lib/**/*.rb']   # optional
+ t.options = ['--output-dir', 'docs/api'] # optional
+ t.stats_options = ['--list-undoc']         # optional
+end
+
+task :default => [:test, :rubocop, :yard]

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache
 .jekyll-metadata
+api

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,3 @@
+_site
+.sass-cache
+.jekyll-metadata

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,24 @@
+---
+layout: default
+---
+
+<style type="text/css" media="screen">
+  .container {
+    margin: 10px auto;
+    max-width: 600px;
+    text-align: center;
+  }
+  h1 {
+    margin: 30px 0;
+    font-size: 4em;
+    line-height: 1;
+    letter-spacing: -1px;
+  }
+</style>
+
+<div class="container">
+  <h1>404</h1>
+
+  <p><strong>Page not found :(</strong></p>
+  <p>The requested page could not be found.</p>
+</div>

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 3.6.2"
+
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+# gem "minima", "~> 2.0"
+gem "jekyll-theme-minimal", "~> 0.1"
+# gem "minimal"
+
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.6"
+end
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "github-pages", group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,39 @@
+# Welcome to Jekyll!
+#
+# This config file is meant for settings that affect your whole blog, values
+# which you are expected to set up once and rarely edit after that. If you find
+# yourself editing this file very often, consider using Jekyll's data files
+# feature for the data you need to update frequently.
+#
+# For technical reasons, this file is *NOT* reloaded automatically when you use
+# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
+
+# Site settings
+# These are used to personalize your new site. If you look in the HTML files,
+# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
+# You can create any custom variable you would like, and they will be accessible
+# in the templates via {{ site.myvariable }}.
+title: OpenCensus for Ruby
+email: your-email@example.com
+description: A stats collection and distributed tracing framework
+baseurl: "/opencensus-ruby" # the subpath of your site, e.g. /blog
+url: "http://opencensus.io" # the base hostname & protocol for your site, e.g. http://example.com
+github_username:  census-instrumentation
+
+# Build settings
+markdown: kramdown
+theme: jekyll-theme-minimal
+plugins:
+  - jekyll-feed
+
+# Exclude from processing.
+# The following items will not be processed, by default. Create a custom list
+# to override the default setting.
+# exclude:
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+
+{% seo %}
+
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <meta name="viewport" content="width=device-width">
+    <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="wrapper">
+      <header>
+        <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        <p>{{ site.description | default: site.github.project_tagline }}</p>
+
+        {% if site.github.is_project_page %}
+          <p class="view"><a href="{{ site.github.repository_url }}">View the Project on GitHub <small>{{ github_name }}</small></a></p>
+        {% endif %}
+        <p class="view"><a href="{{ '/api' | relative_url }}">View the API documentation</a>
+
+        {% if site.github.is_user_page %}
+          <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
+        {% endif %}
+
+        {% if site.show_downloads %}
+          <ul>
+            <li><a href="{{ site.github.zip_url }}">Download <strong>ZIP File</strong></a></li>
+            <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
+            <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
+          </ul>
+        {% endif %}
+      </header>
+      <section>
+
+      {{ content }}
+
+      </section>
+      <footer>
+        {% if site.github.is_project_page %}
+        <p>This project is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
+      </footer>
+    </div>
+    <script src="{{ '/assets/js/scale.fix.js' | relative_url }}"></script>
+
+
+  {% if site.google_analytics %}
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+        ga('create', '{{ site.google_analytics }}', 'auto');
+        ga('send', 'pageview');
+    </script>
+  {% endif %}
+  </body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,76 @@
+---
+# You don't need to edit this file, it's empty on purpose.
+# Edit theme's home layout instead if you wanna make some changes
+# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+layout: default
+---
+
+# OpenCensus for Ruby
+
+## Installation
+
+1. Add `opencensus` to your `Gemfile`:
+
+    ```ruby
+    gem "opencensus"
+    ```
+
+1. Use `bundler` to install the gem:
+
+    ```bash
+    $ bundle install
+    ```
+
+## Tracing on Rack-based frameworks
+
+The OpenCensus library for Ruby makes it easy to integrate OpenCensus tracing
+into popular Rack-based Ruby web frameworks such as Ruby on Rails and
+Sinatra. When the library integration is enabled, it automatically traces
+incoming requests in the application.
+
+### With Ruby on Rails
+
+You can load the Railtie that comes with the library into your Ruby
+on Rails application by explicitly requiring it during the application startup:
+
+```ruby
+# In config/application.rb
+require "opencensus/trace/integrations/rails"
+```
+
+If you're using the `opencensus` gem, it automatically loads the Railtie into
+your application when it starts.
+
+### With other Rack-based frameworks
+
+Other Rack-based frameworks, such as Sinatra, can use the Rack Middleware
+provided by the library:
+
+```ruby
+require "opencensus/trace"
+use OpenCensus::Trace::Integrations::RackMiddleware
+```
+
+### Adding Custom Trace Spans
+
+The OpenCensus Rack Middleware automatically creates a trace record for
+incoming requests. You can add additional custom trace spans within each
+request:
+
+```ruby
+OpenCensus::Trace.in_span "my_task" do |span|
+  # Do stuff...
+
+  OpenCensus::Trace.in_span "my_subtask" do |subspan|
+    # Do other stuff
+  end
+end
+```
+
+### Configuring the library
+
+FIXME
+
+## Supported Ruby Versions
+
+This library is supported on Ruby 2.0+.

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -158,7 +158,7 @@ module OpenCensus
       # SpanContext so subsequent calls no longer create subspans of the
       # finished span.
       #
-      # @param [String] name Name of the span
+      # @param [Span] span The expected, currently active span
       #
       def end_span span
         context = span_context

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -27,7 +27,7 @@ module OpenCensus
         ##
         # Deserialize a trace context header into a TraceContext object.
         #
-        # @param [String]
+        # @param [String] binary
         # @return [TraceContextData, nil]
         #
         def deserialize binary
@@ -42,7 +42,7 @@ module OpenCensus
         ##
         # Serialize a SpanContext object.
         #
-        # @param [SpanContext]
+        # @param [SpanContext] span_context
         # @return [String]
         #
         def serialize span_context

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -26,7 +26,7 @@ module OpenCensus
         ##
         # Deserialize a trace context header into a TraceContext object.
         #
-        # @param [String]
+        # @param [String] header
         # @return [TraceContextData, nil]
         #
         def deserialize header
@@ -44,7 +44,7 @@ module OpenCensus
         ##
         # Serialize a SpanContext object.
         #
-        # @param [SpanContext]
+        # @param [SpanContext] span_context
         # @return [String]
         #
         def serialize span_context

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -31,7 +31,7 @@ module OpenCensus
         ##
         # Deserialize a trace context header into a TraceContext object.
         #
-        # @param [String]
+        # @param [String] header
         # @return [TraceContextData, nil]
         #
         def deserialize header
@@ -53,7 +53,7 @@ module OpenCensus
         ##
         # Serialize a SpanContext object.
         #
-        # @param [SpanContext]
+        # @param [SpanContext] span_context
         # @return [String]
         #
         def serialize span_context

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -256,7 +256,7 @@ module OpenCensus
       # *   Pass in an explicit array of Thread::Backtrace::Location as
       #     returned from Kernel#caller_locations
       #
-      # @param [Array<Thread::Backtrace::Location>, Integer] locations
+      # @param [Array<Thread::Backtrace::Location>, Integer] stack_trace
       #
       def update_stack_trace stack_trace = 0
         @stack_trace =


### PR DESCRIPTION
Fixes #18 

* Default rake task builds yarddoc do docs/api
* On master builds on Travis CI, the docs folder is pushed to gh-pages branch
* GitHub pages should build from the gh-pages branch to http://opencensus.io/opencensus-ruby