### PR TITLE
Move api to root .gitignore so Travis CI will publish them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 /docs/_site
 /docs/Gemfile.lock
+/docs/api/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,3 @@
 _site
 .sass-cache
 .jekyll-metadata
-api


### PR DESCRIPTION
API docs generated by YARD were not being pushed to the gh-pages branch.