### PR TITLE
Custom propagation header

### DIFF
--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -176,6 +176,15 @@ module OpenCensus
         self.span_context = context.parent
         span
       end
+
+      ##
+      # Returns the formatter detected when creating the root span context.
+      #
+      # @return [#serialize,nil]
+      #
+      def detected_formatter
+        span_context.detected_formatter if span_context
+      end
     end
   end
 end

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -24,6 +24,7 @@ require "opencensus/trace/span_builder"
 require "opencensus/trace/span_context"
 require "opencensus/trace/span"
 require "opencensus/trace/status"
+require "opencensus/trace/trace_context_data"
 require "opencensus/trace/truncatable_string"
 
 module OpenCensus

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -83,14 +83,13 @@ module OpenCensus
       # block. When the block finishes, the span context will automatically
       # be unset. If you do not pass a block, this method will return the
       # SpanContext. You must then call `unset_span_context` yourself at the
-      # end of the request.
+      # end of the request
       #
-      # @param [String] header A Trace-Context header (optional)
-      # @param [Hash] rack_env The Rack environment hash (optional)
+      # @param [TraceContextData] trace_context The request's incoming trace
+      #      context (optional)
       #
-      def start_request_trace header: nil, rack_env: nil
-        span_context = SpanContext.create_root \
-          header: header, rack_env: rack_env
+      def start_request_trace trace_context: nil
+        span_context = SpanContext.create_root trace_context: trace_context
         self.span_context = span_context
         if block_given?
           begin

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -176,15 +176,6 @@ module OpenCensus
         self.span_context = context.parent
         span
       end
-
-      ##
-      # Returns the formatter detected when creating the root span context.
-      #
-      # @return [#serialize,nil]
-      #
-      def detected_formatter
-        span_context.detected_formatter if span_context
-      end
     end
   end
 end

--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "opencensus/trace/samplers"
 require "opencensus/trace/exporters"
+require "opencensus/trace/formatters"
+require "opencensus/trace/samplers"
 
 module OpenCensus
   module Trace
@@ -30,6 +31,14 @@ module OpenCensus
         Exporters::Logger.new ::Logger.new(STDOUT, ::Logger::INFO)
       config.add_option! :exporter, default_exporter do |value|
         value.respond_to? :export
+      end
+      default_formatter =
+        Formatters::TraceContext.new
+      config.add_option! :formatter, default_formatter do |value|
+        value.respond_to?(:serialize) &&
+          value.respond_to?(:deserialize) &&
+          value.respond_to?(:header_name) &&
+          value.respond_to?(:rack_header_name)
       end
       config.add_option! :default_max_attributes, 32
       config.add_option! :default_max_stack_frames, 32
@@ -64,6 +73,14 @@ module OpenCensus
       #     an object with a call method that takes a single options hash.
       #     See OpenCensus::Trace::Samplers. The initial value is a Probability
       #     sampler with a default rate.
+      # *   `exporter` The exporter to use. Must be an exporter, an object with
+      #     an export method that takes an array of Span objects. See
+      #     OpenCensus::Trace::Exporters. The initial value is a Logger exporter
+      #     that logs to STDOUT.
+      # *   `formatter` The trace context propagation formatter to use. Must be
+      #     a formatter, an object with serialize, deserialize, header_name,
+      #     and rack_header_name methods. See OpenCensus::Trace::Formatter. The
+      #     initial value is a TraceContext formatter.
       # *   `default_max_attributes` The maximum number of attributes to add to
       #     a span. Initial value is 32. Use 0 for no maximum.
       # *   `default_max_stack_frames` The maximum number of stack frames to

--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -34,7 +34,7 @@ module OpenCensus
       end
       default_formatter =
         Formatters::TraceContext.new
-      config.add_option! :formatter, default_formatter do |value|
+      config.add_option! :http_formatter, default_formatter do |value|
         value.respond_to?(:serialize) &&
           value.respond_to?(:deserialize) &&
           value.respond_to?(:header_name) &&
@@ -70,17 +70,18 @@ module OpenCensus
       # Supported fields are:
       #
       # *   `default_sampler` The default sampler to use. Must be a sampler,
-      #     an object with a call method that takes a single options hash.
+      #     an object with a `call` method that takes a single options hash.
       #     See OpenCensus::Trace::Samplers. The initial value is a Probability
       #     sampler with a default rate.
       # *   `exporter` The exporter to use. Must be an exporter, an object with
       #     an export method that takes an array of Span objects. See
       #     OpenCensus::Trace::Exporters. The initial value is a Logger exporter
       #     that logs to STDOUT.
-      # *   `formatter` The trace context propagation formatter to use. Must be
-      #     a formatter, an object with serialize, deserialize, header_name,
-      #     and rack_header_name methods. See OpenCensus::Trace::Formatter. The
-      #     initial value is a TraceContext formatter.
+      # *   `http_formatter` The trace context propagation formatter to use.
+      #     Must be a formatter, an object with `serialize`, `deserialize`,
+      #     `header_name`, and `rack_header_name` methods. See
+      #     OpenCensus::Trace::Formatter. The initial value is a TraceContext
+      #     formatter.
       # *   `default_max_attributes` The maximum number of attributes to add to
       #     a span. Initial value is 32. Use 0 for no maximum.
       # *   `default_max_stack_frames` The maximum number of stack frames to

--- a/lib/opencensus/trace/formatters.rb
+++ b/lib/opencensus/trace/formatters.rb
@@ -24,9 +24,6 @@ module OpenCensus
     # SpanContext instance.
     #
     module Formatters
-      ## The default context formatter
-      DEFAULT = TraceContext.new
-
       ##
       # Internal struct that holds parsed trace context data.
       #

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -28,7 +28,20 @@ module OpenCensus
         #
         BINARY_FORMAT = "CCH32CH16CC".freeze
 
+        ##
+        # The outgoing header used for the Binary format. There is no
+        # specified header.
+        #
+        # @return [nil]
+        #
         def header_name; end
+
+        ##
+        # The rack environment header used for the Binary format. There is no
+        # specified header.
+        #
+        # @return [nil]
+        #
         def rack_header_name; end
 
         ##

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -44,20 +44,20 @@ module OpenCensus
         end
 
         ##
-        # Serialize a SpanContext object.
+        # Serialize a TraceContextData object.
         #
-        # @param [SpanContext] span_context
+        # @param [TraceContextData] trace_context
         # @return [String]
         #
-        def serialize span_context
+        def serialize trace_context
           [
             0, # version
             0, # field 0
-            span_context.trace_id,
+            trace_context.trace_id,
             1, # field 1
-            span_context.span_id,
+            trace_context.span_id,
             2, # field 2
-            span_context.trace_options
+            trace_context.trace_options
           ].pack(BINARY_FORMAT)
         end
       end

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -28,6 +28,9 @@ module OpenCensus
         #
         BINARY_FORMAT = "CCH32CH16CC".freeze
 
+        def header_name; end
+        def rack_header_name; end
+
         ##
         # Deserialize a trace context header into a TraceContext object.
         #

--- a/lib/opencensus/trace/formatters/binary.rb
+++ b/lib/opencensus/trace/formatters/binary.rb
@@ -29,22 +29,6 @@ module OpenCensus
         BINARY_FORMAT = "CCH32CH16CC".freeze
 
         ##
-        # The outgoing header used for the Binary format. There is no
-        # specified header.
-        #
-        # @return [nil]
-        #
-        def header_name; end
-
-        ##
-        # The rack environment header used for the Binary format. There is no
-        # specified header.
-        #
-        # @return [nil]
-        #
-        def rack_header_name; end
-
-        ##
         # Deserialize a trace context header into a TraceContext object.
         #
         # @param [String] binary

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -27,16 +27,39 @@ module OpenCensus
         #
         HEADER_FORMAT = %r{([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?}
 
-        DEFAULT_HEADER_NAME = "X-Cloud-Trace".freeze
+        ##
+        # The outgoing header used for the Google Cloud Trace header
+        # specification.
+        #
+        # @private
+        #
+        HEADER_NAME = "X-Cloud-Trace".freeze
 
-        attr_reader :header_name
+        ##
+        # The rack environment header used the the Google Cloud Trace header
+        # specification.
+        #
+        # @private
+        #
+        RACK_HEADER_NAME = "HTTP_X_CLOUD_TRACE".freeze
 
-        def initialize header_name = nil
-          @header_name = header_name || DEFAULT_HEADER_NAME
+        ##
+        # Returns the name of the header used for context propagation.
+        #
+        # @return [String]
+        #
+        def header_name
+          HEADER_NAME
         end
 
+        ##
+        # Returns the name of the rack_environment header to use when parsing
+        # context from an incoming request.
+        #
+        # @return [String]
+        #
         def rack_header_name
-          "HTTP_" + @header_name.gsub("-", "_").upcase
+          RACK_HEADER_NAME
         end
 
         ##

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -81,18 +81,18 @@ module OpenCensus
         end
 
         ##
-        # Serialize a SpanContext object.
+        # Serialize a TraceContextData object.
         #
-        # @param [SpanContext] span_context
+        # @param [TraceContextData] trace_context
         # @return [String]
         #
-        def serialize span_context
-          span_context.trace_id.dup.tap do |ret|
-            if span_context.span_id
-              ret << "/" << span_context.span_id.to_i(16).to_s
+        def serialize trace_context
+          trace_context.trace_id.dup.tap do |ret|
+            if trace_context.span_id
+              ret << "/" << trace_context.span_id.to_i(16).to_s
             end
-            if span_context.trace_options
-              ret << ";o=" << span_context.trace_options.to_s
+            if trace_context.trace_options
+              ret << ";o=" << trace_context.trace_options.to_s
             end
           end
         end

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -87,7 +87,7 @@ module OpenCensus
         # @return [String]
         #
         def serialize span_context
-          span_context.trace_id.tap do |ret|
+          span_context.trace_id.dup.tap do |ret|
             if span_context.span_id
               ret << "/" << span_context.span_id.to_i(16).to_s
             end

--- a/lib/opencensus/trace/formatters/cloud_trace.rb
+++ b/lib/opencensus/trace/formatters/cloud_trace.rb
@@ -27,6 +27,18 @@ module OpenCensus
         #
         HEADER_FORMAT = %r{([0-9a-fA-F]{32})(?:\/(\d+))?(?:;o=(\d+))?}
 
+        DEFAULT_HEADER_NAME = "X-Cloud-Trace".freeze
+
+        attr_reader :header_name
+
+        def initialize header_name = nil
+          @header_name = header_name || DEFAULT_HEADER_NAME
+        end
+
+        def rack_header_name
+          "HTTP_" + @header_name.gsub("-", "_").upcase
+        end
+
         ##
         # Deserialize a trace context header into a TraceContext object.
         #
@@ -36,7 +48,7 @@ module OpenCensus
         def deserialize header
           match = HEADER_FORMAT.match(header)
           if match
-            trace_id = match[1]
+            trace_id = match[1].downcase
             span_id = format("%016x", match[2].to_i)
             trace_options = match[3].to_i
             TraceContextData.new trace_id, span_id, trace_options

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -93,18 +93,18 @@ module OpenCensus
         end
 
         ##
-        # Serialize a SpanContext object.
+        # Serialize a TraceContextData object.
         #
-        # @param [SpanContext] span_context
+        # @param [TraceContextData] trace_context
         # @return [String]
         #
-        def serialize span_context
+        def serialize trace_context
           format(
             "%02<version>d-%<trace_id>s-%<span_id>s-%02<trace_options>d",
             version: 0, # version 0,
-            trace_id: span_context.trace_id,
-            span_id: span_context.span_id,
-            trace_options: span_context.trace_options
+            trace_id: trace_context.trace_id,
+            span_id: trace_context.span_id,
+            trace_options: trace_context.trace_options
           )
         end
 

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -36,6 +36,18 @@ module OpenCensus
         HEADER_V0_PATTERN =
           /^([0-9a-fA-F]{32})-([0-9a-fA-F]{16})(-([0-9a-fA-F]{2}))?$/
 
+        DEFAULT_HEADER_NAME = "Trace-Context".freeze
+
+        attr_reader :header_name
+
+        def initialize header_name = nil
+          @header_name = header_name || DEFAULT_HEADER_NAME
+        end
+
+        def rack_header_name
+          "HTTP_" + @header_name.gsub("-", "_").upcase
+        end
+
         ##
         # Deserialize a trace context header into a TraceContext object.
         #

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -36,16 +36,38 @@ module OpenCensus
         HEADER_V0_PATTERN =
           /^([0-9a-fA-F]{32})-([0-9a-fA-F]{16})(-([0-9a-fA-F]{2}))?$/
 
-        DEFAULT_HEADER_NAME = "Trace-Context".freeze
+        ##
+        # The outgoing header used for the TraceContext header specification.
+        #
+        # @private
+        #
+        HEADER_NAME = "Trace-Context".freeze
 
-        attr_reader :header_name
+        ##
+        # The rack environment header used for the TraceContext header
+        # specification
+        #
+        # @private
+        #
+        RACK_HEADER_NAME = "HTTP_TRACE_CONTEXT".freeze
 
-        def initialize header_name = nil
-          @header_name = header_name || DEFAULT_HEADER_NAME
+        ##
+        # Returns the name of the header used for context propagation.
+        #
+        # @return [String]
+        #
+        def header_name
+          HEADER_NAME
         end
 
+        ##
+        # Returns the name of the rack_environment header to use when parsing
+        # context from an incoming request.
+        #
+        # @return [String]
+        #
         def rack_header_name
-          "HTTP_" + @header_name.gsub("-", "_").upcase
+          RACK_HEADER_NAME
         end
 
         ##

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -88,11 +88,13 @@ module OpenCensus
         # @param [#call] sampler The sampler to use when creating spans.
         #     Optional: If omitted, uses the sampler in the current config.
         #
-        def initialize app, span_context: nil, span_name: nil, sampler: nil
+        def initialize app, span_context: nil, span_name: nil, sampler: nil,
+                       formatter: nil
           @app = app
           @span_context = span_context || OpenCensus::Trace
           @span_name = span_name || DEFAULT_SPAN_NAME
           @sampler = sampler
+          @formatter = formatter || Formatters::DEFAULT
         end
 
         ##
@@ -130,9 +132,9 @@ module OpenCensus
           body_size = body.bytesize if body.respond_to? :bytesize
           span.put_attribute "/rpc/request/size", body_size if body_size
 
-          trace_context = span.context.to_trace_context_header
+          trace_context = @formatter.serialize span.context
           headers = env[:request_headers] ||= {}
-          headers["Trace-Context"] = trace_context
+          headers[@formatter.header_name] = trace_context
         end
 
         ##

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -157,8 +157,6 @@ module OpenCensus
           body_size = body.bytesize if body.respond_to? :bytesize
           span.put_attribute "/rpc/request/size", body_size if body_size
 
-          formatter = env[:formatter] || @formatter
-
           trace_context = formatter.serialize span.context
           headers = env[:request_headers] ||= {}
           headers[formatter.header_name] = trace_context

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -65,7 +65,7 @@ module OpenCensus
       #
       # This currently adds a header to each outgoing request, propagating the
       # trace context for distributed tracing. By default, this uses the
-      # TraceContext formatter.
+      # formatter in the current config.
       #
       # You may provide your own implementation of the formatter by configuring
       # it in the middleware options hash. For example:
@@ -104,8 +104,8 @@ module OpenCensus
         # @param [#call] sampler The sampler to use when creating spans.
         #     Optional: If omitted, uses the sampler in the current config.
         # @param [#serialize,#header_name] formatter The formatter to use when
-        #     propagating span context. Optional: If omitted, defaults to the
-        #     TraceContext formatter.
+        #     propagating span context. Optional: If omitted, use the formatter
+        #     in the current config.
         #
         def initialize app, span_context: nil, span_name: nil, sampler: nil,
                        formatter: nil
@@ -113,7 +113,7 @@ module OpenCensus
           @span_context = span_context || OpenCensus::Trace
           @span_name = span_name || DEFAULT_SPAN_NAME
           @sampler = sampler
-          @formatter = formatter || Formatters::DEFAULT
+          @formatter = formatter || OpenCensus::Trace::Config.formatter
         end
 
         ##

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -87,6 +87,9 @@ module OpenCensus
         #     `DEFAULT_SPAN_NAME`
         # @param [#call] sampler The sampler to use when creating spans.
         #     Optional: If omitted, uses the sampler in the current config.
+        # @param [#serialize,#header_name] formatter The formatter to use when
+        #     propagating span context. Optional: If omitted, uses the
+        #     TraceContext formatter.
         #
         def initialize app, span_context: nil, span_name: nil, sampler: nil,
                        formatter: nil
@@ -94,7 +97,9 @@ module OpenCensus
           @span_context = span_context || OpenCensus::Trace
           @span_name = span_name || DEFAULT_SPAN_NAME
           @sampler = sampler
-          @formatter = formatter || Formatters::DEFAULT
+          @formatter = formatter
+          @formatter ||= span_context.detected_formatter if span_context
+          @formatter ||= Formatters::DEFAULT
         end
 
         ##

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -152,7 +152,7 @@ module OpenCensus
           span.put_attribute "/rpc/request/size", body_size if body_size
 
           formatter = env[:formatter] || @formatter
-          trace_context = formatter.serialize span.context
+          trace_context = formatter.serialize span.context.trace_context
           headers = env[:request_headers] ||= {}
           headers[formatter.header_name] = trace_context
         end

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -105,8 +105,9 @@ module OpenCensus
         # @param [#call] sampler The sampler to use when creating spans.
         #     Optional: If omitted, uses the sampler in the current config.
         # @param [#serialize,#header_name] formatter The formatter to use when
-        #     propagating span context. Optional: If omitted, uses the
-        #     TraceContext formatter.
+        #     propagating span context. Optional: If omitted, uses the formatter
+        #     detected by the span context. If no formatter was detected,
+        #     defaults to the TraceContext formatter.
         #
         def initialize app, span_context: nil, span_name: nil, sampler: nil,
                        formatter: nil

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -113,7 +113,7 @@ module OpenCensus
           @span_context = span_context || OpenCensus::Trace
           @span_name = span_name || DEFAULT_SPAN_NAME
           @sampler = sampler
-          @formatter = formatter || OpenCensus::Trace::Config.formatter
+          @formatter = formatter || OpenCensus::Trace::Config.http_formatter
         end
 
         ##

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -69,7 +69,7 @@ module OpenCensus
         # @return [SpanContext]
         #
         def create_root header: nil, rack_env: nil, formatter: nil
-          formatter ||= detect_formatter(rack_env) || Formatters::DEFAULT
+          formatter ||= detect_formatter(rack_env) || Config.formatter
           header ||= rack_env[formatter.rack_header_name] if rack_env
           trace_context = formatter.deserialize header if header
 

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -25,8 +25,8 @@ module OpenCensus
       #
       # @private
       #
-      TraceData = Struct.new :trace_id, :trace_options, :span_map, :rack_env,
-                             :formatter
+      TraceData = Struct.new :trace_id, :trace_options, :span_map, :rack_env
+
       ##
       # Maximum integer value for a `trace_id`
       #
@@ -69,21 +69,19 @@ module OpenCensus
         # @return [SpanContext]
         #
         def create_root header: nil, rack_env: nil, formatter: nil
-          detected_formatter = detect_formatter rack_env
-          formatter ||= detected_formatter || Formatters::DEFAULT
+          formatter ||= detect_formatter(rack_env) || Formatters::DEFAULT
           header ||= rack_env[formatter.rack_header_name] if rack_env
           trace_context = formatter.deserialize header if header
 
           if trace_context
             trace_data = TraceData.new \
-              trace_context.trace_id, trace_context.trace_options, {}, rack_env,
-              detected_formatter
+              trace_context.trace_id, trace_context.trace_options, {}, rack_env
             new trace_data, nil, trace_context.span_id
           else
             trace_id = rand 1..MAX_TRACE_ID
             trace_id = trace_id.to_s(16).rjust(32, "0")
             trace_data = TraceData.new \
-              trace_id, 0, {}, rack_env, detected_formatter
+              trace_id, 0, {}, rack_env
             new trace_data, nil, ""
           end
         end
@@ -144,15 +142,6 @@ module OpenCensus
       #
       def trace_options
         @trace_data.trace_options
-      end
-
-      ##
-      # Returns the formatter detected when creating the root span context.
-      #
-      # @return [#serialize,nil]
-      #
-      def detected_formatter
-        @trace_data.formatter
       end
 
       ##

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -62,6 +62,9 @@ module OpenCensus
         #
         # @param [String] header A Trace-Context header (optional)
         # @param [Hash] rack_env The Rack environment hash (optional)
+        # @param [#serialize,#rack_header_name] formatter The formatter to use
+        #     when propagating span context. Optional: If omitted, uses the
+        #     TraceContext formatter.
         #
         # @return [SpanContext]
         #
@@ -74,13 +77,13 @@ module OpenCensus
           if trace_context
             trace_data = TraceData.new \
               trace_context.trace_id, trace_context.trace_options, {}, rack_env,
-              formatter
+              detected_formatter
             new trace_data, nil, trace_context.span_id
           else
             trace_id = rand 1..MAX_TRACE_ID
             trace_id = trace_id.to_s(16).rjust(32, "0")
             trace_data = TraceData.new \
-              trace_id, 0, {}, rack_env, formatter
+              trace_id, 0, {}, rack_env, detected_formatter
             new trace_data, nil, ""
           end
         end
@@ -141,6 +144,15 @@ module OpenCensus
       #
       def trace_options
         @trace_data.trace_options
+      end
+
+      ##
+      # Returns the formatter detected when creating the root span context.
+      #
+      # @return [#serialize,nil]
+      #
+      def detected_formatter
+        @trace_data.formatter
       end
 
       ##

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -69,7 +69,7 @@ module OpenCensus
         # @return [SpanContext]
         #
         def create_root header: nil, rack_env: nil, formatter: nil
-          formatter ||= detect_formatter(rack_env) || Config.formatter
+          formatter ||= detect_formatter(rack_env) || Config.http_formatter
           header ||= rack_env[formatter.rack_header_name] if rack_env
           trace_context = formatter.deserialize header if header
 
@@ -80,8 +80,7 @@ module OpenCensus
           else
             trace_id = rand 1..MAX_TRACE_ID
             trace_id = trace_id.to_s(16).rjust(32, "0")
-            trace_data = TraceData.new \
-              trace_id, 0, {}, rack_env
+            trace_data = TraceData.new trace_id, 0, {}, rack_env
             new trace_data, nil, ""
           end
         end

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -41,10 +41,16 @@ module OpenCensus
       #
       MAX_SPAN_ID = 0xffffffffffffffff
 
+      ##
+      # List of trace context formatters we use to parse the parent span
+      # context.
+      #
+      # @private
+      #
       AUTODETECTABLE_FORMATTERS = [
         Formatters::CloudTrace.new,
         Formatters::TraceContext.new
-      ]
+      ].freeze
 
       class << self
         ##
@@ -61,7 +67,7 @@ module OpenCensus
         #
         def create_root header: nil, rack_env: nil, formatter: nil
           detected_formatter = detect_formatter rack_env
-          formatter = detected_formatter || Formatters::DEFAULT
+          formatter ||= detected_formatter || Formatters::DEFAULT
           header ||= rack_env[formatter.rack_header_name] if rack_env
           trace_context = formatter.deserialize header if header
 

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -98,6 +98,15 @@ module OpenCensus
       end
 
       ##
+      # Returns the trace context for this span.
+      #
+      # @return [TraceContextData]
+      #
+      def trace_context
+        TraceContextData.new trace_id, @span_id, trace_options
+      end
+
+      ##
       # The trace ID, as a 32-character hex string.
       #
       # @return [String]
@@ -207,7 +216,7 @@ module OpenCensus
       # @return [SpanBuilder, nil] The span defining this context.
       #
       def this_span
-        get_span span_id
+        get_span @span_id
       end
 
       ##

--- a/lib/opencensus/trace/trace_context_data.rb
+++ b/lib/opencensus/trace/trace_context_data.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 OpenCensus Authors
+# Copyright 2018 OpenCensus Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,18 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "opencensus/trace/formatters/binary"
-require "opencensus/trace/formatters/cloud_trace"
-require "opencensus/trace/formatters/trace_context"
-
 module OpenCensus
   module Trace
     ##
-    # The Formatters module contains several implementations of cross-service
-    # SpanContext propagation. Each formatter can serialize and deserialize a
-    # TraceContextData instance.
+    # Struct that holds parsed trace context data.
     #
-    module Formatters
-    end
+    TraceContextData = Struct.new :trace_id, :span_id, :trace_options
   end
 end

--- a/test/trace/formatters/binary_test.rb
+++ b/test/trace/formatters/binary_test.rb
@@ -37,7 +37,6 @@ describe OpenCensus::Trace::Formatters::Binary do
       OpenCensus::Trace::SpanContext::TraceData.new(
         "123456789012345678901234567890ab",
         1,
-        {},
         {}
       )
     end

--- a/test/trace/formatters/cloud_trace_test.rb
+++ b/test/trace/formatters/cloud_trace_test.rb
@@ -37,7 +37,6 @@ describe OpenCensus::Trace::Formatters::CloudTrace do
       OpenCensus::Trace::SpanContext::TraceData.new(
         "123456789012345678901234567890ab",
         1,
-        {},
         {}
       )
     end

--- a/test/trace/formatters/trace_context_test.rb
+++ b/test/trace/formatters/trace_context_test.rb
@@ -42,7 +42,6 @@ describe OpenCensus::Trace::Formatters::TraceContext do
       OpenCensus::Trace::SpanContext::TraceData.new(
         "0123456789abcdef0123456789abcdef",
         1,
-        {},
         {}
       )
     end

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -159,5 +159,20 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       header = env[:request_headers]["Trace-Context"]
       header.must_match %r{^00-#{span.trace_id}-#{span.span_id}}
     end
+
+    it "should allow specific trace context formats" do
+      middleware = OpenCensus::Trace::Integrations::FaradayMiddleware.new \
+        app(code: 200, body: nil), span_context: root_context,
+        formatter: OpenCensus::Trace::Formatters::CloudTrace.new
+      env = {
+        method: "POST",
+        url: "https://www.google.com/"
+      }
+      middleware.call env
+      span = root_context.build_contained_spans.first
+
+      header = env[:request_headers]["X-Cloud-Trace"]
+      header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)};o=}
+    end
   end
 end

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -174,5 +174,28 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       header = env[:request_headers]["X-Cloud-Trace"]
       header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)}}
     end
+
+    describe "global configuration" do
+      before do
+        @original_formatter = OpenCensus::Trace::Config.formatter
+        OpenCensus::Trace::Config.formatter =
+          OpenCensus::Trace::Formatters::CloudTrace.new
+      end
+      after { OpenCensus::Trace::Config.formatter = @original_formatter }
+
+      it "should allow trace context formats" do
+        middleware = OpenCensus::Trace::Integrations::FaradayMiddleware.new \
+          app(code: 200, body: nil), span_context: root_context
+        env = {
+          method: "POST",
+          url: "https://www.google.com/"
+        }
+        middleware.call env
+        span = root_context.build_contained_spans.first
+
+        header = env[:request_headers]["X-Cloud-Trace"]
+        header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)}}
+      end
+    end
   end
 end

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -174,26 +174,5 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       header = env[:request_headers]["X-Cloud-Trace"]
       header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)}}
     end
-
-    it "should default to the request's detected formatter" do
-      rack_env = {
-        "HTTP_X_CLOUD_TRACE" =>
-          "0123456789ABCDEF0123456789abcdef/81985529216486895;o=1"
-      }
-      root_context = OpenCensus::Trace::SpanContext.create_root \
-        rack_env: rack_env
-      middleware = OpenCensus::Trace::Integrations::FaradayMiddleware.new \
-        app(code: 200, body: nil), span_context: root_context,
-        formatter: OpenCensus::Trace::Formatters::CloudTrace.new
-      env = {
-        method: "POST",
-        url: "https://www.google.com/"
-      }
-      middleware.call env
-      span = root_context.build_contained_spans.first
-
-      header = env[:request_headers]["X-Cloud-Trace"]
-      header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)}}
-    end
   end
 end

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -172,7 +172,28 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       span = root_context.build_contained_spans.first
 
       header = env[:request_headers]["X-Cloud-Trace"]
-      header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)};o=}
+      header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)}}
+    end
+
+    it "should default to the request's detected formatter" do
+      rack_env = {
+        "HTTP_X_CLOUD_TRACE" =>
+          "0123456789ABCDEF0123456789abcdef/81985529216486895;o=1"
+      }
+      root_context = OpenCensus::Trace::SpanContext.create_root \
+        rack_env: rack_env
+      middleware = OpenCensus::Trace::Integrations::FaradayMiddleware.new \
+        app(code: 200, body: nil), span_context: root_context,
+        formatter: OpenCensus::Trace::Formatters::CloudTrace.new
+      env = {
+        method: "POST",
+        url: "https://www.google.com/"
+      }
+      middleware.call env
+      span = root_context.build_contained_spans.first
+
+      header = env[:request_headers]["X-Cloud-Trace"]
+      header.must_match %r{^#{span.trace_id}/#{span.span_id.to_i(16)}}
     end
   end
 end

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -177,11 +177,11 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
 
     describe "global configuration" do
       before do
-        @original_formatter = OpenCensus::Trace::Config.formatter
-        OpenCensus::Trace::Config.formatter =
+        @original_formatter = OpenCensus::Trace::Config.http_formatter
+        OpenCensus::Trace::Config.http_formatter =
           OpenCensus::Trace::Formatters::CloudTrace.new
       end
-      after { OpenCensus::Trace::Config.formatter = @original_formatter }
+      after { OpenCensus::Trace::Config.http_formatter = @original_formatter }
 
       it "should allow trace context formats" do
         middleware = OpenCensus::Trace::Integrations::FaradayMiddleware.new \

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -16,6 +16,10 @@ require "test_helper"
 
 describe OpenCensus::Trace::SpanContext do
   describe "create_root" do
+    let(:trace_context) do
+      OpenCensus::Trace::Formatters::TraceContextData.new \
+        "0123456789abcdef0123456789abcdef", "0123456789abcdef", 1
+    end
     it "populates defaults" do
       span_context = OpenCensus::Trace::SpanContext.create_root
       span_context.parent.must_be_nil
@@ -25,66 +29,13 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_options.must_equal 0
     end
 
-    it "parses a directly given Trace-Context header" do
-      header = "00-0123456789ABCDEF0123456789abcdef-0123456789ABCdef-01"
-      span_context = OpenCensus::Trace::SpanContext.create_root header: header
+    it "uses a parsed trace context" do
+      span_context = OpenCensus::Trace::SpanContext.create_root trace_context: trace_context
       span_context.parent.must_be_nil
       span_context.root.must_be_same_as span_context
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
-    end
-
-    it "parses trace-context header from rack environment" do
-      env = {
-        "HTTP_TRACE_CONTEXT" =>
-          "00-0123456789ABCDEF0123456789abcdef-0123456789ABCdef-01"
-      }
-      span_context = OpenCensus::Trace::SpanContext.create_root rack_env: env
-      span_context.parent.must_be_nil
-      span_context.root.must_be_same_as span_context
-      span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
-      span_context.span_id.must_equal "0123456789abcdef"
-      span_context.trace_options.must_equal 1
-    end
-
-    it "parses x-cloud-trace header from rack environment" do
-      env = {
-        "HTTP_X_CLOUD_TRACE" =>
-          "0123456789ABCDEF0123456789abcdef/81985529216486895;o=1"
-      }
-      span_context = OpenCensus::Trace::SpanContext.create_root rack_env: env
-      span_context.parent.must_be_nil
-      span_context.root.must_be_same_as span_context
-      span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
-      span_context.span_id.must_equal "0123456789abcdef"
-      span_context.trace_options.must_equal 1
-    end
-
-    it "falls back to default for a missing header" do
-      env = {
-        "HTTP_TRACE_CONTEXT1" =>
-          "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
-      }
-      span_context = OpenCensus::Trace::SpanContext.create_root rack_env: env
-      span_context.parent.must_be_nil
-      span_context.root.must_be_same_as span_context
-      span_context.trace_id.must_match %r{^[0-9a-f]{32}$}
-      span_context.span_id.must_equal ""
-      span_context.trace_options.must_equal 0
-    end
-
-    it "falls back to default for an invalid version" do
-      env = {
-        "HTTP_TRACE_CONTEXT" =>
-          "ff-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
-      }
-      span_context = OpenCensus::Trace::SpanContext.create_root rack_env: env
-      span_context.parent.must_be_nil
-      span_context.root.must_be_same_as span_context
-      span_context.trace_id.must_match %r{^[0-9a-f]{32}$}
-      span_context.span_id.must_equal ""
-      span_context.trace_options.must_equal 0
     end
   end
 

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -33,6 +33,7 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
+      span_context.detected_formatter.must_be_nil
     end
 
     it "parses trace-context header from rack environment" do
@@ -46,6 +47,8 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
+      span_context.detected_formatter.must_be_kind_of \
+        OpenCensus::Trace::Formatters::TraceContext
     end
 
     it "parses x-cloud-trace header from rack environment" do
@@ -59,6 +62,8 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
+      span_context.detected_formatter.must_be_kind_of \
+        OpenCensus::Trace::Formatters::CloudTrace
     end
 
     it "falls back to default for a missing header" do

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -33,7 +33,6 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
-      span_context.detected_formatter.must_be_nil
     end
 
     it "parses trace-context header from rack environment" do
@@ -47,8 +46,6 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
-      span_context.detected_formatter.must_be_kind_of \
-        OpenCensus::Trace::Formatters::TraceContext
     end
 
     it "parses x-cloud-trace header from rack environment" do
@@ -62,8 +59,6 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
-      span_context.detected_formatter.must_be_kind_of \
-        OpenCensus::Trace::Formatters::CloudTrace
     end
 
     it "falls back to default for a missing header" do

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -17,7 +17,7 @@ require "test_helper"
 describe OpenCensus::Trace::SpanContext do
   describe "create_root" do
     let(:trace_context) do
-      OpenCensus::Trace::Formatters::TraceContextData.new \
+      OpenCensus::Trace::TraceContextData.new \
         "0123456789abcdef0123456789abcdef", "0123456789abcdef", 1
     end
     it "populates defaults" do

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -33,8 +33,6 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
-      span_context.to_trace_context_header.must_equal \
-        "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
     end
 
     it "parses trace-context header from rack environment" do
@@ -48,8 +46,19 @@ describe OpenCensus::Trace::SpanContext do
       span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
       span_context.span_id.must_equal "0123456789abcdef"
       span_context.trace_options.must_equal 1
-      span_context.to_trace_context_header.must_equal \
-        "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+    end
+
+    it "parses x-cloud-trace header from rack environment" do
+      env = {
+        "HTTP_X_CLOUD_TRACE" =>
+          "0123456789ABCDEF0123456789abcdef/81985529216486895;o=1"
+      }
+      span_context = OpenCensus::Trace::SpanContext.create_root rack_env: env
+      span_context.parent.must_be_nil
+      span_context.root.must_be_same_as span_context
+      span_context.trace_id.must_equal "0123456789abcdef0123456789abcdef"
+      span_context.span_id.must_equal "0123456789abcdef"
+      span_context.trace_options.must_equal 1
     end
 
     it "falls back to default for a missing header" do

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -17,6 +17,10 @@ require "test_helper"
 describe OpenCensus::Trace do
   let(:simple_context) { OpenCensus::Trace::SpanContext.create_root }
   let(:header) { "00-0123456789abcdef0123456789abcdef-0123456789abcdef-00" }
+  let(:trace_context) do
+    OpenCensus::Trace::Formatters::TraceContextData.new \
+      "0123456789abcdef0123456789abcdef", "0123456789abcdef", 1
+  end
 
   describe "span context" do
     after {
@@ -32,7 +36,7 @@ describe OpenCensus::Trace do
     end
 
     it "is initialized when a request trace starts" do
-      OpenCensus::Trace.start_request_trace header: header
+      OpenCensus::Trace.start_request_trace trace_context: trace_context
       OpenCensus::Trace.span_context.trace_id.must_equal \
         "0123456789abcdef0123456789abcdef"
       OpenCensus::Trace.span_context.span_id.must_equal \
@@ -41,7 +45,7 @@ describe OpenCensus::Trace do
     end
 
     it "is cleared after a request trace block" do
-      OpenCensus::Trace.start_request_trace header: header do |ctx|
+      OpenCensus::Trace.start_request_trace trace_context: trace_context do |ctx|
         OpenCensus::Trace.span_context.must_equal ctx
       end
       OpenCensus::Trace.span_context.must_be_nil
@@ -50,7 +54,7 @@ describe OpenCensus::Trace do
 
   describe "default context" do
     before {
-      OpenCensus::Trace.start_request_trace header: header
+      OpenCensus::Trace.start_request_trace trace_context: trace_context
     }
     after {
       OpenCensus::Trace.unset_span_context

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -18,7 +18,7 @@ describe OpenCensus::Trace do
   let(:simple_context) { OpenCensus::Trace::SpanContext.create_root }
   let(:header) { "00-0123456789abcdef0123456789abcdef-0123456789abcdef-00" }
   let(:trace_context) do
-    OpenCensus::Trace::Formatters::TraceContextData.new \
+    OpenCensus::Trace::TraceContextData.new \
       "0123456789abcdef0123456789abcdef", "0123456789abcdef", 1
   end
 


### PR DESCRIPTION
Fixes #29 

* Extends the formatter duck type to include `header_name` and `rack_header_name`.
* Detect the formatter from the available request headers if available.
* Faraday middleware accepts a custom formatter, or defaults to detected formatter from the request.