### PR TITLE
Update configs to match features in google/cloud/config

### DIFF
--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -50,7 +50,7 @@ module OpenCensus
 
     # Expose the trace config as a subconfig under the main config.
     OpenCensus.configure do |config|
-      config.add_config! :trace, Config
+      config.add_alias! :trace, config: Config
     end
 
     class << self


### PR DESCRIPTION
We've been iterating a bit on the configs design in google-cloud-ruby (see https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1912). This is to bring the opencensus version of configs more in line with what we converged on over there. (Alas, it looks like we can't actually merge the two, because of some weirdness in the requirements on the google-cloud-ruby side, but this at least makes them more similar so I don't get as confused when moving between them.)

Specifics:

* Aliases, allowing you to have multiple names/paths for the same config. We've used this in google-cloud-ruby when we want to rename a field but maintain backward compatibility.
* A reset feature, which lets you reset an option value to the original default. We used this often to clean up after tests.
* A delete feature, which deletes a field altogether, including all its defaults/validation/etc. Again, this is sometimes used to clean up after tests—particularly if we want to test the defaults by "reloading" them.
* Fixed a few annoyances, e.g. `allow_nil` is now set by default if the initial value is nil.
