### PR TITLE
Remove extraneous OpenCensus::Trace::Config constant

### DIFF
--- a/lib/opencensus/common/config.rb
+++ b/lib/opencensus/common/config.rb
@@ -30,7 +30,7 @@ module OpenCensus
     #
     # Example:
     #
-    #     config = OpenCensus::Config.new do |c|
+    #     config = OpenCensus::Common::Config.new do |c|
     #       c.add_option! :opt1, 10
     #       c.add_option! :opt2, :one, enum: [:one, :two, :three]
     #       c.add_option! :opt3, "hi", match: [String, Symbol]
@@ -64,7 +64,7 @@ module OpenCensus
     #     config.opt4 = 3.14      #=> exception (not in allowed types)
     #     config.opt4 = nil       #=> nil  (nil explicitly allowed)
     #
-    #     config.sub              #=> <OpenCensus::Config>
+    #     config.sub              #=> <OpenCensus::Common::Config>
     #
     #     config.sub.opt5         #=> false
     #     config.sub.opt5 = true  #=> true  (true and false allowed)

--- a/lib/opencensus/config.rb
+++ b/lib/opencensus/config.rb
@@ -15,34 +15,40 @@
 require "opencensus/common/config"
 
 module OpenCensus
-  ##
   # The OpenCensus overall configuration.
-  #
-  Config = Common::Config.new
+  @config = Common::Config.new
 
-  ##
-  # Configure OpenCensus. Most configuration parameters are part of
-  # subconfigurations that live under this main configuration.
-  #
-  # If the OpenCensus Railtie is installed in a Rails application, the toplevel
-  # configuration object is also exposed as `config.opencensus`.
-  #
-  # Generally, you should configure this once at process initialization,
-  # but it can be modified at any time.
-  #
-  # Example:
-  #
-  #     OpenCensus.configure do |config|
-  #       config.trace.default_sampler =
-  #         OpenCensus::Trace::Samplers::AlwaysSample.new
-  #       config.trace.default_max_attributes = 16
-  #     end
-  #
-  def self.configure
-    if block_given?
-      yield Config
-    else
-      Config
+  class << self
+    ##
+    # Configure OpenCensus. Most configuration parameters are part of
+    # subconfigurations that live under this main configuration.
+    #
+    # If the OpenCensus Railtie is installed in a Rails application, the
+    # toplevel configuration object is also exposed as `config.opencensus`.
+    #
+    # Generally, you should configure this once at process initialization,
+    # but it can be modified at any time.
+    #
+    # Example:
+    #
+    #     OpenCensus.configure do |config|
+    #       config.trace.default_sampler =
+    #         OpenCensus::Trace::Samplers::AlwaysSample.new
+    #       config.trace.default_max_attributes = 16
+    #     end
+    #
+    def configure
+      if block_given?
+        yield @config
+      else
+        @config
+      end
     end
+
+    ##
+    # Get the current configuration.
+    # @private
+    #
+    attr_reader :config
   end
 end

--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -18,10 +18,8 @@ require "opencensus/trace/samplers"
 
 module OpenCensus
   module Trace
-    ##
-    # The OpenCensus Trace configuration. See Trace#configure for more info.
-    #
-    Config = Common::Config.new do |config|
+    # Schema of the Trace configuration. See Trace#configure for more info.
+    @config = Common::Config.new do |config|
       default_sampler =
         Samplers::Probability.new Samplers::Probability::DEFAULT_RATE
       config.add_option! :default_sampler, default_sampler do |value|
@@ -50,7 +48,7 @@ module OpenCensus
 
     # Expose the trace config as a subconfig under the main config.
     OpenCensus.configure do |config|
-      config.add_alias! :trace, config: Config
+      config.add_alias! :trace, config: @config
     end
 
     class << self
@@ -105,9 +103,9 @@ module OpenCensus
       #
       def configure
         if block_given?
-          yield Config
+          yield @config
         else
-          Config
+          @config
         end
       end
     end

--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -108,6 +108,12 @@ module OpenCensus
           @config
         end
       end
+
+      ##
+      # Get the current configuration
+      # @private
+      #
+      attr_reader :config
     end
   end
 end

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -113,7 +113,7 @@ module OpenCensus
           @span_context = span_context || OpenCensus::Trace
           @span_name = span_name || DEFAULT_SPAN_NAME
           @sampler = sampler
-          @formatter = formatter || OpenCensus::Trace.configure.http_formatter
+          @formatter = formatter || OpenCensus::Trace.config.http_formatter
         end
 
         ##

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -113,7 +113,7 @@ module OpenCensus
           @span_context = span_context || OpenCensus::Trace
           @span_name = span_name || DEFAULT_SPAN_NAME
           @sampler = sampler
-          @formatter = formatter || OpenCensus::Trace::Config.http_formatter
+          @formatter = formatter || OpenCensus::Trace.configure.http_formatter
         end
 
         ##

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -51,7 +51,7 @@ module OpenCensus
         #
         def initialize app, exporter: nil
           @app = app
-          @exporter = exporter || OpenCensus::Trace.configure.exporter
+          @exporter = exporter || OpenCensus::Trace.config.exporter
         end
 
         ##

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -51,7 +51,7 @@ module OpenCensus
         #
         def initialize app, exporter: nil
           @app = app
-          @exporter = exporter || OpenCensus::Trace::Config.exporter
+          @exporter = exporter || OpenCensus::Trace.configure.exporter
         end
 
         ##

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -400,20 +400,16 @@ module OpenCensus
                        max_message_events: nil,
                        max_links: nil,
                        max_string_length: nil
-          @max_attributes =
-            max_attributes || OpenCensus::Trace::Config.default_max_attributes
+          config = OpenCensus::Trace.configure
+          @max_attributes = max_attributes || config.default_max_attributes
           @max_stack_frames =
-            max_stack_frames ||
-            OpenCensus::Trace::Config.default_max_stack_frames
-          @max_annotations =
-            max_annotations || OpenCensus::Trace::Config.default_max_annotations
+            max_stack_frames || config.default_max_stack_frames
+          @max_annotations = max_annotations || config.default_max_annotations
           @max_message_events =
-            max_message_events ||
-            OpenCensus::Trace::Config.default_max_message_events
-          @max_links = max_links || OpenCensus::Trace::Config.default_max_links
+            max_message_events || config.default_max_message_events
+          @max_links = max_links || config.default_max_links
           @max_string_length =
-            max_string_length ||
-            OpenCensus::Trace::Config.default_max_string_length
+            max_string_length || config.default_max_string_length
         end
 
         ##

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -400,7 +400,7 @@ module OpenCensus
                        max_message_events: nil,
                        max_links: nil,
                        max_string_length: nil
-          config = OpenCensus::Trace.configure
+          config = OpenCensus::Trace.config
           @max_attributes = max_attributes || config.default_max_attributes
           @max_stack_frames =
             max_stack_frames || config.default_max_stack_frames

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -163,7 +163,7 @@ module OpenCensus
       #
       def start_span name, skip_frames: 0, sampler: nil
         child_context = create_child
-        sampler ||= OpenCensus::Trace.configure.default_sampler
+        sampler ||= OpenCensus::Trace.config.default_sampler
         sampled = sampler.call span_context: self
         span = SpanBuilder.new child_context, sampled,
                                skip_frames: skip_frames + 1

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -163,7 +163,7 @@ module OpenCensus
       #
       def start_span name, skip_frames: 0, sampler: nil
         child_context = create_child
-        sampler ||= OpenCensus::Trace::Config.default_sampler
+        sampler ||= OpenCensus::Trace.configure.default_sampler
         sampled = sampler.call span_context: self
         span = SpanBuilder.new child_context, sampled,
                                skip_frames: skip_frames + 1

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -177,11 +177,13 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
 
     describe "global configuration" do
       before do
-        @original_formatter = OpenCensus::Trace::Config.http_formatter
-        OpenCensus::Trace::Config.http_formatter =
+        @original_formatter = OpenCensus::Trace.configure.http_formatter
+        OpenCensus::Trace.configure.http_formatter =
           OpenCensus::Trace::Formatters::CloudTrace.new
       end
-      after { OpenCensus::Trace::Config.http_formatter = @original_formatter }
+      after do
+        OpenCensus::Trace.configure.http_formatter = @original_formatter
+      end
 
       it "should allow trace context formats" do
         middleware = OpenCensus::Trace::Integrations::FaradayMiddleware.new \

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -177,12 +177,12 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
 
     describe "global configuration" do
       before do
-        @original_formatter = OpenCensus::Trace.configure.http_formatter
-        OpenCensus::Trace.configure.http_formatter =
+        @original_formatter = OpenCensus::Trace.config.http_formatter
+        OpenCensus::Trace.config.http_formatter =
           OpenCensus::Trace::Formatters::CloudTrace.new
       end
       after do
-        OpenCensus::Trace.configure.http_formatter = @original_formatter
+        OpenCensus::Trace.config.http_formatter = @original_formatter
       end
 
       it "should allow trace context formats" do

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -102,10 +102,12 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
 
     describe "custom exporter" do
       before do
-        @original_exporter = OpenCensus::Trace::Config.exporter
-        OpenCensus::Trace::Config.exporter = exporter
+        @original_exporter = OpenCensus::Trace.configure.exporter
+        OpenCensus::Trace.configure.exporter = exporter
       end
-      after { OpenCensus::Trace::Config.exporter = @original_exporter }
+      after do
+        OpenCensus::Trace.configure.exporter = @original_exporter
+      end
       let(:middleware) { OpenCensus::Trace::Integrations::RackMiddleware.new app }
 
       it "should capture the request" do

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -102,11 +102,11 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
 
     describe "custom exporter" do
       before do
-        @original_exporter = OpenCensus::Trace.configure.exporter
-        OpenCensus::Trace.configure.exporter = exporter
+        @original_exporter = OpenCensus::Trace.config.exporter
+        OpenCensus::Trace.config.exporter = exporter
       end
       after do
-        OpenCensus::Trace.configure.exporter = @original_exporter
+        OpenCensus::Trace.config.exporter = @original_exporter
       end
       let(:middleware) { OpenCensus::Trace::Integrations::RackMiddleware.new app }
 

--- a/test/trace/span_builder_test.rb
+++ b/test/trace/span_builder_test.rb
@@ -208,7 +208,7 @@ describe OpenCensus::Trace::SpanBuilder::PieceBuilder do
     end
 
     it "should honor default maxes" do
-      default_max = OpenCensus::Trace.configure.default_max_string_length
+      default_max = OpenCensus::Trace.config.default_max_string_length
       str = "*" * (default_max + 10)
       ts = builder_with_default_maxes.truncatable_string str
       ts.value.must_equal("*" * default_max)

--- a/test/trace/span_builder_test.rb
+++ b/test/trace/span_builder_test.rb
@@ -208,7 +208,7 @@ describe OpenCensus::Trace::SpanBuilder::PieceBuilder do
     end
 
     it "should honor default maxes" do
-      default_max = OpenCensus::Trace::Config.default_max_string_length
+      default_max = OpenCensus::Trace.configure.default_max_string_length
       str = "*" * (default_max + 10)
       ts = builder_with_default_maxes.truncatable_string str
       ts.value.must_equal("*" * default_max)


### PR DESCRIPTION
There are already a lot of ways to get to the config. The `OpenCensus::Trace::Config` constant is extraneous (and a bit confusing because it's not a class or module even though the name looks like one). Removing it.