### PR TITLE
Fix policy around nullable fields

### DIFF
--- a/lib/opencensus/trace/message_event.rb
+++ b/lib/opencensus/trace/message_event.rb
@@ -58,7 +58,7 @@ module OpenCensus
       # The number of compressed bytes sent or received. If zero, assumed to
       # be the same size as uncompressed.
       #
-      # @return [Integer, nil]
+      # @return [Integer]
       #
       attr_reader :compressed_size
 
@@ -67,7 +67,7 @@ module OpenCensus
       #
       # @private
       #
-      def initialize type, id, uncompressed_size, compressed_size: nil,
+      def initialize type, id, uncompressed_size, compressed_size: 0,
                      time: nil
         super time: time
         @type = type

--- a/lib/opencensus/trace/span.rb
+++ b/lib/opencensus/trace/span.rb
@@ -158,7 +158,7 @@ module OpenCensus
       # crosses a process boundary. True when the parent_span belongs to the
       # same process as the current span.
       #
-      # @return [Boolean]
+      # @return [boolean, nil]
       #
       attr_reader :same_process_as_parent_span
 
@@ -183,7 +183,7 @@ module OpenCensus
                      dropped_annotations_count: 0,
                      dropped_message_events_count: 0, links: [],
                      dropped_links_count: 0, status: nil,
-                     same_process_as_parent_span: true,
+                     same_process_as_parent_span: nil,
                      child_span_count: nil
         @name = name
         @trace_id = trace_id


### PR DESCRIPTION
This fixes `nil`-ability for a few fields to match the policy in the proto spec. Specifically:

* `MessageEvent.compressed_size` is defined as non-nullable in the proto (where the zero value is special). Fix the documentation here and don't default to `nil` which is actually invalid.
* `Span. same_process_as_parent_span` is defined as optional (nullable) in the proto. Fix the documentation and set the default to `nil`.