### PR TITLE
Set optional span fields if possible

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,8 @@ YARD::Rake::YardocTask.new do |t|
  t.stats_options = ['--list-undoc']         # optional
 end
 
+task :faster do
+  ENV["FASTER_TESTS"] = "true"
+end
+
 task :default => [:test, :rubocop, :yard]

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -88,9 +88,13 @@ module OpenCensus
       #
       # @param [TraceContextData] trace_context The request's incoming trace
       #      context (optional)
+      # @param [boolean, nil] is_local_context Set to `true` if the parent
+      #      span is local, `false` if it is remote, or `nil` if there is no
+      #      parent span or this information is not available.
       #
-      def start_request_trace trace_context: nil
-        span_context = SpanContext.create_root trace_context: trace_context
+      def start_request_trace trace_context: nil, is_local_context: nil
+        span_context = SpanContext.create_root \
+          trace_context: trace_context, is_local_context: is_local_context
         self.span_context = span_context
         if block_given?
           begin

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -88,13 +88,14 @@ module OpenCensus
       #
       # @param [TraceContextData] trace_context The request's incoming trace
       #      context (optional)
-      # @param [boolean, nil] is_local_context Set to `true` if the parent
+      # @param [boolean, nil] same_process_as_parent Set to `true` if the parent
       #      span is local, `false` if it is remote, or `nil` if there is no
       #      parent span or this information is not available.
       #
-      def start_request_trace trace_context: nil, is_local_context: nil
+      def start_request_trace trace_context: nil, same_process_as_parent: nil
         span_context = SpanContext.create_root \
-          trace_context: trace_context, is_local_context: is_local_context
+          trace_context: trace_context,
+          same_process_as_parent: same_process_as_parent
         self.span_context = span_context
         if block_given?
           begin

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -70,8 +70,9 @@ module OpenCensus
             context = formatter.deserialize env[formatter.rack_header_name]
           end
 
-          Trace.start_request_trace trace_context: context,
-                                    is_local_context: false do |span_context|
+          Trace.start_request_trace \
+            trace_context: context,
+            same_process_as_parent: false do |span_context|
             begin
               span_context.in_span get_path(env) do |span|
                 start_request span, env

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -70,7 +70,8 @@ module OpenCensus
             context = formatter.deserialize env[formatter.rack_header_name]
           end
 
-          Trace.start_request_trace trace_context: context do |span_context|
+          Trace.start_request_trace trace_context: context,
+                                    is_local_context: false do |span_context|
             begin
               span_context.in_span get_path(env) do |span|
                 start_request span, env

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -279,6 +279,21 @@ module OpenCensus
       ##
       # Return a read-only version of this span
       #
+      # @param [Integer, nil] max_attributes The maximum number of attributes
+      #     to save, or `nil` to use the config value.
+      # @param [Integer, nil] max_stack_frames The maximum number of stack
+      #     frames to save, or `nil` to use the config value.
+      # @param [Integer, nil] max_annotations The maximum number of annotations
+      #     to save, or `nil` to use the config value.
+      # @param [Integer, nil] max_message_events The maximum number of message
+      #     events to save, or `nil` to use the config value.
+      # @param [Integer, nil] max_links The maximum number of links to save,
+      #     or `nil` to use the config value.
+      # @param [Integer, nil] max_string_length The maximum length in bytes for
+      #     truncated strings, or `nil` to use the config value.
+      # @param [Integer, nil] child_span_count The number of child spans to
+      #     declare, or `nil` to omit the `child_span_count` field.
+      #
       # @return [Span]
       #
       def to_span max_attributes: nil,
@@ -287,7 +302,7 @@ module OpenCensus
                   max_message_events: nil,
                   max_links: nil,
                   max_string_length: nil,
-                  same_process_as_parent_span: nil
+                  child_span_count: nil
 
         raise "Span must have start_time" unless @start_time
         raise "Span must have end_time" unless @end_time
@@ -312,6 +327,7 @@ module OpenCensus
         built_links = builder.convert_links @links
         dropped_links_count = @links.size - built_links.size
         built_status = builder.convert_status @status_code, @status_message
+        same_process_as_parent_span = context.parent.local?
 
         Span.new trace_id, span_id, built_name, @start_time, @end_time,
                  parent_span_id: parent_span_id,
@@ -325,7 +341,8 @@ module OpenCensus
                  links: built_links,
                  dropped_links_count: dropped_links_count,
                  status: built_status,
-                 same_process_as_parent_span: same_process_as_parent_span
+                 same_process_as_parent_span: same_process_as_parent_span,
+                 child_span_count: child_span_count
       end
 
       # rubocop:enable Metrics/MethodLength

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -327,7 +327,7 @@ module OpenCensus
         built_links = builder.convert_links @links
         dropped_links_count = @links.size - built_links.size
         built_status = builder.convert_status @status_code, @status_message
-        same_process_as_parent_span = context.parent.local?
+        same_process_as_parent_span = context.parent.same_process_as_parent
 
         Span.new trace_id, span_id, built_name, @start_time, @end_time,
                  parent_span_id: parent_span_id,

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -51,18 +51,18 @@ module OpenCensus
         #
         # @param [TraceContextData] trace_context The request's incoming trace
         #      context (optional)
-        # @param [boolean, nil] is_local_context Set to `true` if the parent
-        #      span is local, `false` if it is remote, or `nil` if there is no
-        #      parent span or this information is not available.
+        # @param [boolean, nil] same_process_as_parent Set to `true` if the
+        #      parent span is local, `false` if it is remote, or `nil` if there
+        #      is no parent span or this information is not available.
         #
         # @return [SpanContext]
         #
-        def create_root trace_context: nil, is_local_context: nil
+        def create_root trace_context: nil, same_process_as_parent: nil
           if trace_context
             trace_data = TraceData.new \
               trace_context.trace_id, trace_context.trace_options, {}
             new trace_data, nil, trace_context.span_id,
-                is_local_context
+                same_process_as_parent
           else
             trace_id = rand 1..MAX_TRACE_ID
             trace_id = trace_id.to_s(16).rjust(32, "0")
@@ -142,9 +142,7 @@ module OpenCensus
       #
       # @return [boolean, nil]
       #
-      def local?
-        @is_local_context
-      end
+      attr_reader :same_process_as_parent
 
       ##
       # Whether the context (e.g. the parent span) has been sampled. This
@@ -279,11 +277,11 @@ module OpenCensus
       #
       # @private
       #
-      def initialize trace_data, parent, span_id, is_local_context
+      def initialize trace_data, parent, span_id, same_process_as_parent
         @trace_data = trace_data
         @parent = parent
         @span_id = span_id
-        @is_local_context = is_local_context
+        @same_process_as_parent = same_process_as_parent
       end
 
       ##

--- a/test/trace/formatters/binary_test.rb
+++ b/test/trace/formatters/binary_test.rb
@@ -41,7 +41,7 @@ describe OpenCensus::Trace::Formatters::Binary do
       )
     end
     let(:span_context) do
-      OpenCensus::Trace::SpanContext.new trace_data, nil, "00000000000004d2"
+      OpenCensus::Trace::SpanContext.new trace_data, nil, "00000000000004d2", nil
     end
 
     it "should serialize a SpanContext object" do

--- a/test/trace/formatters/cloud_trace_test.rb
+++ b/test/trace/formatters/cloud_trace_test.rb
@@ -41,7 +41,7 @@ describe OpenCensus::Trace::Formatters::CloudTrace do
       )
     end
     let(:span_context) do
-      OpenCensus::Trace::SpanContext.new trace_data, nil, "00000000000004d2"
+      OpenCensus::Trace::SpanContext.new trace_data, nil, "00000000000004d2", nil
     end
 
     it "should serialize a SpanContext object" do

--- a/test/trace/formatters/trace_context_test.rb
+++ b/test/trace/formatters/trace_context_test.rb
@@ -46,7 +46,7 @@ describe OpenCensus::Trace::Formatters::TraceContext do
       )
     end
     let(:span_context) do
-      OpenCensus::Trace::SpanContext.new trace_data, nil, "0123456789abcdef"
+      OpenCensus::Trace::SpanContext.new trace_data, nil, "0123456789abcdef", nil
     end
 
     it "should serialize a SpanContext object" do

--- a/test/trace/integrations/rails_integration_test.rb
+++ b/test/trace/integrations/rails_integration_test.rb
@@ -93,9 +93,10 @@ describe "Rails integration" do
     end
   end
 
-  RailsTestHelper.create_rails_app
+  RailsTestHelper.create_rails_app unless ENV["FASTER_TESTS"]
 
   it "traces incoming requests" do
+    skip if ENV["FASTER_TESTS"]
     RailsTestHelper.run_rails_app do |stream|
       result = RailsTestHelper.rails_request "/"
       result.must_equal "OK"

--- a/test/trace/span_builder_test.rb
+++ b/test/trace/span_builder_test.rb
@@ -170,7 +170,7 @@ describe OpenCensus::Trace::SpanBuilder do
       trace_context = OpenCensus::Trace::TraceContextData.new \
         "0123456789abcdef0123456789abcdef", "0123456789abcdef", 1
       remote_context = OpenCensus::Trace::SpanContext.create_root \
-        is_local_context: false, trace_context: trace_context
+        same_process_as_parent: false, trace_context: trace_context
       sb1 = remote_context.start_span "span1"
       sb1.finish!
       sb1.to_span.same_process_as_parent_span.must_equal false


### PR DESCRIPTION
This attempts to set the optional but recommended `same_process_as_parent_span` field in the `Span` object. It also provides a path for advanced clients to set the `child_span_count` field, but doesn't automatically compute it for now.

The `same_process_as_parent_span` can generally be set to true for spans except when the root span context is built with a trace context originating out of process. Since this information is known only by the calling application, we provide it to the constructor via an `is_local_context` argument. It defaults to `nil` (i.e. unknown). It is also set to `nil` if there is no parent span (because the spec is not clear on what to do in that case). Otherwise, the Rack middleware sets it to `false` because it's creating a context based on an incoming request header, so we know those parents are remote. And, all span contexts other than the root set it to true because they are being created from the root, and thus in-process.

The `child_span_count` field is much more risky because it depends on the trace context not having been transmitted to any downstream remote processes (which we don't control). In addition, it participates in data validation if present, so it is crucial it be set correctly or not at all. This PR adds it as a field to `SpanBuilder#to_span` but otherwise does not attempt to compute it.

Finally, I fixed a few documentation items; and I added a way to skip the rails integration test, which isn't *that* slow, but it's slow enough to be annoying when iterating with the test suite.