### PR TITLE
Release version 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Release History
+
+### 0.2.0 / 2018-02-13
+
+* Span creation sets the "same_process_as_parent_span" field if possible.
+* The "stack_trace_hash_id" field was missing from the interfaces. Fixed.
+* Nullability of a few fields did not match the proto specs. Fixed.
+* Fixed some documentation errors and omissions.
+
+### 0.1.0 / 2018-01-12
+
+Initial release of the core library, including:
+
+* Trace interfaces
+* Rack integration
+* Rails integration
+* Faraday integration
+* Logging exporter

--- a/lib/opencensus/version.rb
+++ b/lib/opencensus/version.rb
@@ -14,5 +14,5 @@
 
 module OpenCensus
   ## Current OpenCensus version
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end

--- a/opencensus.gemspec
+++ b/opencensus.gemspec
@@ -6,8 +6,8 @@ require "opencensus/version"
 Gem::Specification.new do |spec|
   spec.name          = "opencensus"
   spec.version       = OpenCensus::VERSION
-  spec.authors       = ["Jeff Ching"]
-  spec.email         = ["chingor@google.com"]
+  spec.authors       = ["Jeff Ching", "Daniel Azuma"]
+  spec.email         = ["chingor@google.com", "dazuma@google.com"]
 
   spec.summary       = %q{A stats collection and distributed tracing framework}
   spec.description   = %q{A stats collection and distributed tracing framework}


### PR DESCRIPTION
Bumping to 0.2 because a few of the interfaces are slightly changed, and the current WIP stackdriver exporter plugin will not work with the 0.1 interfaces.