### PR TITLE
Several minor fixes

### DIFF
--- a/lib/opencensus/trace/integrations.rb
+++ b/lib/opencensus/trace/integrations.rb
@@ -18,6 +18,11 @@ module OpenCensus
     # The Integrations module contains implementations of integrations with
     # popular gems such as Rails and Faraday.
     #
+    # Integrations are not loaded by default. To use an integration,
+    # require it explicitly. e.g.:
+    #
+    #     require "opencensus/trace/integrations/rack_middleware"
+    #
     module Integrations
     end
   end

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -14,6 +14,8 @@
 
 require "faraday"
 
+require "opencensus"
+
 module OpenCensus
   module Trace
     module Integrations

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "opencensus"
+
 module OpenCensus
   module Trace
     module Integrations

--- a/lib/opencensus/trace/span.rb
+++ b/lib/opencensus/trace/span.rb
@@ -177,7 +177,7 @@ module OpenCensus
       # @private
       #
       def initialize trace_id, span_id, name, start_time, end_time,
-                     parent_span_id: nil, attributes: {},
+                     parent_span_id: "", attributes: {},
                      dropped_attributes_count: 0, stack_trace: [],
                      dropped_frames_count: 0, time_events: [],
                      dropped_annotations_count: 0,


### PR DESCRIPTION
A couple minor fixes:

* Required the main "opencensus" path from the integration files. Fixes #49 
* Set `parent_span_id` default in the `Span` constructor to the empty string, since nil is not a legal value.
