### PR TITLE
Fix tests for ruby versions since 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
-before_install: gem install bundler -v 1.15.1
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
+before_install: gem install bundler -v 1.16.1
 script:
   - bundle exec rake
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ and
 
 ### Supported Ruby Versions
 
-This library is supported on Ruby 2.0+.
+This library is supported on Ruby 2.2+.
 
 ### Versioning
 

--- a/lib/opencensus/common/config.rb
+++ b/lib/opencensus/common/config.rb
@@ -217,9 +217,7 @@ module OpenCensus
       #
       def reset! key = nil
         if key.nil?
-          # rubocop:disable Performance/HashEachMethods
           @fields.keys.each { |k| reset! k }
-          # rubocop:enable Performance/HashEachMethods
         else
           key = key.to_sym
           unless @fields.key? key
@@ -385,7 +383,11 @@ module OpenCensus
       # @return [Hash]
       #
       def to_h!
-        @fields.transform_values { |v| v.is_a?(Config) ? v.to_h! : v.value }
+        result = {}
+        @fields.each do |k, v|
+          result[k] = v.is_a?(Config) ? v.to_h! : v.value
+        end
+        result
       end
 
       ##

--- a/opencensus.gemspec
+++ b/opencensus.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.2.0"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/test/trace/exporters/logger_test.rb
+++ b/test/trace/exporters/logger_test.rb
@@ -15,7 +15,12 @@
 require "test_helper"
 
 describe OpenCensus::Trace::Exporters::Logger do
-  let(:logger) { ::Logger.new(STDOUT, level: ::Logger::INFO, formatter: -> (_, _, _, msg) { msg }) }
+  let(:logger) {
+    logger = ::Logger.new STDOUT
+    logger.level = ::Logger::INFO
+    logger.formatter = -> (_, _, _, msg) { msg }
+    logger
+  }
 
   describe "export" do
     let(:spans) { [OpenCensus::Trace::Span.new("traceid", "spanid", "name", Time.new, Time.new)] }


### PR DESCRIPTION
Cleanup and fixes for tests against Ruby versions since 2.2.

* Declared that the library requires Ruby 2.2, since earlier versions are EOL.
* Updated travis config to test against Rubies between 2.2 and 2.5
* Fix config so it doesn't depend on an API that was added in Ruby 2.4
* Fix logger test so it doesn't depend on an API that was added in Ruby 2.4