### PR TITLE
Implement multi exporter, and document the exporter interface

### DIFF
--- a/lib/opencensus/trace/exporters.rb
+++ b/lib/opencensus/trace/exporters.rb
@@ -13,12 +13,31 @@
 # limitations under the License.
 
 require "opencensus/trace/exporters/logger"
+require "opencensus/trace/exporters/multi"
 
 module OpenCensus
   module Trace
     ##
     # The Exporters module provides integrations for exporting collected trace
-    # spans to an external or local service.
+    # spans to an external or local service. Exporter classes may be put inside
+    # this module, but are not required to be located here.
+    #
+    # An exporter is an object that must respond to the following method:
+    #
+    #     def export(spans)
+    #
+    # Where `spans` is an array of {OpenCensus::Trace::Span} objects to export.
+    # The method _must_ tolerate any number of spans in the `spans` array,
+    # including an empty array.
+    #
+    # The method return value is not defined.
+    #
+    # The exporter object may interpret the `export` message in whatever way it
+    # deems appropriate. For example, it may write the data to a log file, it
+    # may transmit it to a monitoring service, or it may do nothing at all.
+    # An exporter may also queue the request for later asynchronous processing,
+    # and indeed this is recommended if the export involves time consuming
+    # operations such as remote API calls.
     #
     module Exporters
     end

--- a/lib/opencensus/trace/exporters/logger.rb
+++ b/lib/opencensus/trace/exporters/logger.rb
@@ -40,7 +40,6 @@ module OpenCensus
         # Export the captured spans to the configured logger.
         #
         # @param [Array<Span>] spans The captured spans.
-        # @return [Boolean]
         #
         def export spans
           @logger.log @level, spans.map { |span| format_span(span) }.to_json

--- a/lib/opencensus/trace/exporters/logger.rb
+++ b/lib/opencensus/trace/exporters/logger.rb
@@ -43,6 +43,7 @@ module OpenCensus
         #
         def export spans
           @logger.log @level, spans.map { |span| format_span(span) }.to_json
+          nil
         end
 
         private

--- a/lib/opencensus/trace/exporters/multi.rb
+++ b/lib/opencensus/trace/exporters/multi.rb
@@ -48,7 +48,7 @@ module OpenCensus
         #
         def export spans
           each { |delegate| delegate.export spans }
-          true
+          nil
         end
       end
     end

--- a/lib/opencensus/trace/exporters/multi.rb
+++ b/lib/opencensus/trace/exporters/multi.rb
@@ -1,0 +1,56 @@
+# Copyright 2018 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "delegate"
+
+module OpenCensus
+  module Trace
+    module Exporters
+      ##
+      # The Multi exporter multiplexes captured spans to a set of delegate
+      # exporters. It is useful if you need to export to more than one
+      # destination. You may also use it as a "null" exporter by providing
+      # no delegates.
+      #
+      # Multi delegates to an array of the exporter objects. You can manage
+      # the list of exporters using any method of Array. For example:
+      #
+      #     multi = OpenCensus::Trace::Exporters::Multi.new
+      #     multi.export(spans)  # Does nothing
+      #     multi << OpenCensus::Trace::Exporters::Logger.new
+      #     multi.export(spans)  # Exports to the logger
+      #
+      class Multi < SimpleDelegator
+        ##
+        # Create a new Multi exporter
+        #
+        # @param [Array<#export>] delegates An array of exporters
+        #
+        def initialize *delegates
+          super(delegates.flatten)
+        end
+
+        ##
+        # Pass the captured spans to the delegates.
+        #
+        # @param [Array<Span>] spans The captured spans.
+        #
+        def export spans
+          each { |delegate| delegate.export spans }
+          true
+        end
+      end
+    end
+  end
+end

--- a/test/trace/exporters/logger_test.rb
+++ b/test/trace/exporters/logger_test.rb
@@ -25,21 +25,19 @@ describe OpenCensus::Trace::Exporters::Logger do
   describe "export" do
     let(:spans) { [OpenCensus::Trace::Span.new("traceid", "spanid", "name", Time.new, Time.new)] }
 
-    it "should return true on successful log" do
+    it "should emit data for a covered log level" do
       exporter = OpenCensus::Trace::Exporters::Logger.new logger, level: ::Logger::INFO
       out, _err = capture_subprocess_io do
-        res = exporter.export spans
-        res.must_equal true
+        exporter.export spans
       end
 
       out.wont_be_empty
     end
 
-    it "should return true on skipped log" do
+    it "should not emit data for a low log level" do
       exporter = OpenCensus::Trace::Exporters::Logger.new logger, level: ::Logger::DEBUG
       out, _err = capture_subprocess_io do
-        res = exporter.export spans
-        res.must_equal true
+        exporter.export spans
       end
 
       out.must_be_empty

--- a/test/trace/exporters/multi_test.rb
+++ b/test/trace/exporters/multi_test.rb
@@ -1,0 +1,52 @@
+# Copyright 2017 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "test_helper"
+
+describe OpenCensus::Trace::Exporters::Multi do
+  describe "export" do
+    let(:spans) { ["span1", "span2"] }
+
+    it "should delegate to exporters" do
+      mock1 = Minitest::Mock.new
+      mock1.expect :export, nil, [spans]
+      mock2 = Minitest::Mock.new
+      mock2.expect :export, nil, [spans]
+
+      exporter = OpenCensus::Trace::Exporters::Multi.new mock1, mock2
+      exporter.export spans
+
+      mock1.verify
+      mock2.verify
+    end
+
+    it "should allow empty" do
+      exporter = OpenCensus::Trace::Exporters::Multi.new
+      exporter.export spans
+    end
+  end
+
+  describe "array management" do
+    let(:exporter1) { "exporter1" }
+    let(:exporter2) { "exporter2" }
+
+    it "allows adding to the multi and retrieving by index" do
+      exporter = OpenCensus::Trace::Exporters::Multi.new
+      exporter << exporter1
+      exporter.push exporter2
+      exporter[0].must_equal exporter1
+      exporter[1].must_equal exporter2
+    end
+  end
+end


### PR DESCRIPTION
We discussed at one point doing a "multi" exporter to handle the multiple exporter case, so we don't have to have the exporter config value be an array. Doing this. (This also covers the use case of a "null" exporter.)

Also documented the exporter interface.