### PR TITLE
Fix middleware ordering for Rails integration

### DIFF
--- a/lib/opencensus/trace/integrations/rails.rb
+++ b/lib/opencensus/trace/integrations/rails.rb
@@ -129,7 +129,7 @@ module OpenCensus
           where = OpenCensus::Trace.configure.middleware_placement
           case where
           when Class
-            middleware_stack.insert where, RackMiddleware
+            middleware_stack.insert_before where, RackMiddleware
           when :begin
             middleware_stack.unshift RackMiddleware
           else


### PR DESCRIPTION
I ran into a problem where we're currently inserting the middleware before a specific middleware (`::Rack::Runtime`) in the rails stack, but this will fail if that middleware has been removed. Default instead to append the middleware to the end of the stack, and provide a config that lets an application move it to the beginning, or position it before a specific middleware of the application's choosing.