### PR TITLE
Create hello-world example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /docs/_site
 /docs/Gemfile.lock
 /docs/api/
+
+/examples/*/Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ into the request so you can potentially connect your request trace with that of
 the remote service. Here is an example:
 
 ```ruby
+require "opencensus/trace/integrations/rack_middleware"
 conn = Faraday.new(url: "http://www.example.com") do |c|
   c.use OpenCensus::Trace::Integrations::FaradayMiddleware
   c.adapter Faraday.default_adapter
-  end
+end
 conn.get "/"
 ```
 

--- a/examples/hello-world/Gemfile
+++ b/examples/hello-world/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "sinatra", "~> 2.0"
-gem "opencensus", "~> 0.2"
 gem "faraday", "~> 0.14"
+gem "opencensus", "~> 0.2"
+gem "sinatra", "~> 2.0"

--- a/examples/hello-world/Gemfile
+++ b/examples/hello-world/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "sinatra", "~> 2.0"
+gem "opencensus", "~> 0.2"
+gem "faraday", "~> 0.14"

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,33 @@
+# Hello World example
+
+This example application demonstrates how to use OpenCensus to record traces for a Sinatra-based web application.
+
+## Prerequisites
+
+Ruby 2.2 or later is required. Make sure you have Bundler installed as well.
+
+    gem install bundler
+
+## Installation
+
+Get the example from the OpenCensus Ruby repository on Github, and cd into the example application directory.
+
+    git clone https://github.com/census-instrumentation/opencensus-ruby.git
+    cd opencensus-ruby/examples/hello-world
+
+Install the dependencies using Bundler.
+
+    bundle install
+
+## Running the example
+
+Run the application locally on your workstation with:
+
+    bundle exec ruby hello.rb
+
+This will run on port 4567 by default, and display application logs on the terminal. From a separate shell, you can send requests using a tool such as curl:
+
+    curl http://localhost:4567/
+    curl http://localhost:4567/lengthy
+
+The running application will log the captured traces.

--- a/examples/hello-world/hello.rb
+++ b/examples/hello-world/hello.rb
@@ -1,0 +1,59 @@
+# Copyright 2018 OpenCensus Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is a simple Sinatra application demonstrating how to record traces
+# using OpenCensus.
+#
+# It uses the OpenCensus Rack middleware to trace all incoming requests. It
+# also demonstrates how to use the Faraday middleware to trace outgoing HTTP
+# requests, as well as how to instrument your code to capture custom spans.
+#
+# By default, the resulting trace data is logged in JSON format. You can also
+# configure OpenCensus to report traces to a backend such as Stackdriver or
+# Zipkin using an exporter plugin library.
+
+require "sinatra"
+
+# Install the Rack middleware to trace incoming requests.
+require "opencensus/trace/integrations/rack_middleware"
+use OpenCensus::Trace::Integrations::RackMiddleware
+
+# Access the Faraday middleware which will be used to trace outgoing HTTP
+# requests.
+require "opencensus/trace/integrations/faraday_middleware"
+
+# Each request will be traced automatically by the middleware.
+get "/" do
+  "Hello world!"
+end
+
+# Traces for this request will also include sub-spans as indicated below.
+get "/lengthy" do
+  # Configure this Faraday connection with a middleware to trace outgoing
+  # requests.
+  conn = Faraday.new(url: "http://www.google.com") do |c|
+    c.use OpenCensus::Trace::Integrations::FaradayMiddleware
+    c.adapter Faraday.default_adapter
+  end
+  conn.get "/"
+
+  # You may instrument your code to create custom spans for long-running
+  # operations.
+  OpenCensus::Trace.in_span "long task" do |span|
+    sleep rand
+  end
+
+  "Done!"
+end

--- a/examples/hello-world/hello.rb
+++ b/examples/hello-world/hello.rb
@@ -51,7 +51,7 @@ get "/lengthy" do
 
   # You may instrument your code to create custom spans for long-running
   # operations.
-  OpenCensus::Trace.in_span "long task" do |span|
+  OpenCensus::Trace.in_span "long task" do
     sleep rand
   end
 


### PR DESCRIPTION
Add an examples directory with an initial hello-world example. This will be referenced from the Ruby quickstart page on the opencensus website.