### PR TITLE
Building honors sampling setting; change default sampler to always

### DIFF
--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -20,8 +20,7 @@ module OpenCensus
   module Trace
     # Schema of the Trace configuration. See Trace#configure for more info.
     @config = Common::Config.new do |config|
-      default_sampler =
-        Samplers::Probability.new Samplers::Probability::DEFAULT_RATE
+      default_sampler = Samplers::AlwaysSample.new
       config.add_option! :default_sampler, default_sampler do |value|
         value.respond_to? :call
       end

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -232,9 +232,9 @@ module OpenCensus
       end
 
       ##
-      # Builds all finished spans under this context, and returns an array of
-      # built `Span` objects. Ignores any unfinished spans. The order of the
-      # generated spans is undefined.
+      # Builds spans under this context, and returns an array of built `Span`
+      # objects. Builds only spans that are both finished and sampled, and
+      # ignores others. The order of the generated spans is undefined.
       #
       # Does not build any ancestor spans. If you want the entire span tree
       # built, call this method on the `#root` context.
@@ -260,7 +260,10 @@ module OpenCensus
                                 max_message_events: nil,
                                 max_links: nil,
                                 max_string_length: nil
-        contained_span_builders.find_all(&:finished?).map do |sb|
+        sampled_span_builders = contained_span_builders.find_all do |sb|
+          sb.finished? && sb.sampled
+        end
+        sampled_span_builders.map do |sb|
           sb.to_span max_attributes: max_attributes,
                      max_stack_frames: max_stack_frames,
                      max_annotations: max_annotations,

--- a/test/trace/span_context_test.rb
+++ b/test/trace/span_context_test.rb
@@ -172,6 +172,15 @@ describe OpenCensus::Trace::SpanContext do
       spans.first.name.value.must_equal "hello"
     end
 
+    it "omits unsampled spans" do
+      span1.sampled = false
+      span2.finish!
+      span1.finish!
+      spans = root_context.build_contained_spans
+      spans.size.must_equal 1
+      spans.first.name.value.must_equal "world"
+    end
+
     it "omits spans not contained in the context" do
       span2.finish!
       span1.finish!


### PR DESCRIPTION
Fix `SpanContext#build_contained_spans` so it honors the `sampled` setting and builds only sampled spans for export. Add a test for it.

Also changed default sampler to `AlwaysSample`. This will preserve the earlier default behavior (all spans are exported—previous because the sampling bit was ignored, now because all spans are sampled by default). This will also ensure the best getting-started experience for new users who may be confused if their traces are sampled out when they're first trying to get the system to work.
