### PR TITLE
Implement SpanKind

### DIFF
--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -124,16 +124,18 @@ module OpenCensus
       # Will throw an exception if there is no current SpanContext.
       #
       # @param [String] name Name of the span
+      # @param [Symbol] kind Kind of span. Defaults to unspecified.
       # @param [Sampler] sampler Span-scoped sampler. If not provided,
       #     defaults to the trace configuration's default sampler.
       #
       # @return [SpanBuilder] A SpanBuilder object that you can use to
       #     set span attributes and create children.
       #
-      def start_span name, skip_frames: 0, sampler: nil
+      def start_span name, kind: nil, skip_frames: 0, sampler: nil
         context = span_context
         raise "No currently active span context" unless context
-        span = context.start_span name, skip_frames: skip_frames + 1,
+        span = context.start_span name, kind: kind,
+                                        skip_frames: skip_frames + 1,
                                         sampler: sampler
         self.span_context = span.context
         span
@@ -151,11 +153,13 @@ module OpenCensus
       # will create subspans.
       #
       # @param [String] name Name of the span
+      # @param [Symbol] kind Kind of span. Defaults to unspecified.
       # @param [Sampler] sampler Span-scoped sampler. If not provided,
       #     defaults to the trace configuration's default sampler.
       #
-      def in_span name, skip_frames: 0, sampler: nil
-        span = start_span name, skip_frames: skip_frames + 1, sampler: sampler
+      def in_span name, kind: nil, skip_frames: 0, sampler: nil
+        span = start_span name, kind: kind, skip_frames: skip_frames + 1,
+                                sampler: sampler
         begin
           yield span
         ensure

--- a/lib/opencensus/trace/exporters/logger.rb
+++ b/lib/opencensus/trace/exporters/logger.rb
@@ -54,6 +54,7 @@ module OpenCensus
         def format_span span
           {
             name: format_value(span.name),
+            kind: span.kind,
             trace_id: span.trace_id,
             span_id: span.span_id,
             parent_span_id: span.parent_span_id,

--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -145,6 +145,7 @@ module OpenCensus
         # @private Set span attributes from request object
         #
         def start_request span, env
+          span.kind = SpanBuilder::CLIENT
           req_method = env[:method]
           span.put_attribute "/http/method", req_method if req_method
           url = env[:url]

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -111,6 +111,7 @@ module OpenCensus
         end
 
         def start_request span, env
+          span.kind = SpanBuilder::SERVER
           span.put_attribute "/http/host", get_host(env)
           span.put_attribute "/http/url", get_url(env)
           span.put_attribute "/http/method", env["REQUEST_METHOD"]

--- a/lib/opencensus/trace/span.rb
+++ b/lib/opencensus/trace/span.rb
@@ -220,9 +220,8 @@ module OpenCensus
         @attributes = attributes
         @dropped_attributes_count = dropped_attributes_count
         @stack_trace = stack_trace
-        @stack_trace_hash_id = [stack_trace, dropped_frames_count].hash
-        @stack_trace_hash_id = -1 if @stack_trace_hash_id.zero?
         @dropped_frames_count = dropped_frames_count
+        @stack_trace_hash_id = init_stack_trace_hash_id
         @time_events = time_events
         @dropped_annotations_count = dropped_annotations_count
         @dropped_message_events_count = dropped_message_events_count
@@ -231,6 +230,13 @@ module OpenCensus
         @status = status
         @same_process_as_parent_span = same_process_as_parent_span
         @child_span_count = child_span_count
+      end
+
+      private
+
+      def init_stack_trace_hash_id
+        hash_id = [@stack_trace, @dropped_frames_count].hash
+        hash_id.zero? ? -1 : hash_id
       end
     end
   end

--- a/lib/opencensus/trace/span.rb
+++ b/lib/opencensus/trace/span.rb
@@ -20,6 +20,21 @@ module OpenCensus
     # or have a parent span, and may have zero or more children.
     #
     class Span
+      ## The span kind is unspecified
+      SPAN_KIND_UNSPECIFIED = :SPAN_KIND_UNSPECIFIED
+
+      ##
+      # Indicates that the span covers server-side handling of an RPC or other
+      # remote network request.
+      #
+      SERVER = :SERVER
+
+      ##
+      # Indicates that the span covers the client-side wrapper around an RPC
+      # or other remote request.
+      #
+      CLIENT = :CLIENT
+
       ##
       # A unique identifier for a trace. All spans from the same trace share
       # the same `trace_id`. The ID is a 16-byte value represented as a
@@ -53,6 +68,15 @@ module OpenCensus
       # @return [TruncatableString]
       #
       attr_reader :name
+
+      ##
+      # The kind of span. Can be used to specify additional relationships
+      # between spans in addition to a parent/child relationship.
+      # You should use the kind constants provided by this class.
+      #
+      # @return [Symbol]
+      #
+      attr_reader :kind
 
       ##
       # The starting timestamp of this span in UTC.
@@ -177,6 +201,7 @@ module OpenCensus
       # @private
       #
       def initialize trace_id, span_id, name, start_time, end_time,
+                     kind: SPAN_KIND_UNSPECIFIED,
                      parent_span_id: "", attributes: {},
                      dropped_attributes_count: 0, stack_trace: [],
                      dropped_frames_count: 0, time_events: [],
@@ -186,6 +211,7 @@ module OpenCensus
                      same_process_as_parent_span: nil,
                      child_span_count: nil
         @name = name
+        @kind = kind
         @trace_id = trace_id
         @span_id = span_id
         @parent_span_id = parent_span_id

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -33,6 +33,21 @@ module OpenCensus
       ## The linked span is a parent of the current span.
       PARENT_LINKED_SPAN = :PARENT_LINKED_SPAN
 
+      ## The span kind is unspecified
+      SPAN_KIND_UNSPECIFIED = :SPAN_KIND_UNSPECIFIED
+
+      ##
+      # Indicates that the span covers server-side handling of an RPC or other
+      # remote network request.
+      #
+      SERVER = :SERVER
+
+      ##
+      # Indicates that the span covers the client-side wrapper around an RPC
+      # or other remote request.
+      #
+      CLIENT = :CLIENT
+
       ##
       # The context that can build children of this span.
       #
@@ -89,6 +104,18 @@ module OpenCensus
       # @return [String, TruncatableString]
       #
       attr_accessor :name
+
+      ##
+      # The kind of span. Can be used to specify additional relationships
+      # between spans in addition to a parent/child relationship.
+      # Valid values are `SpanBuilder::CLIENT`, `SpanBuilder::SERVER`, and
+      # `SpanBuilder::SPAN_KIND_UNSPECIFIED`.
+      #
+      # This field is required.
+      #
+      # @return [Symbol]
+      #
+      attr_accessor :kind
 
       ##
       # The start time of the span. On the client side, this is the time kept
@@ -330,6 +357,7 @@ module OpenCensus
         same_process_as_parent_span = context.parent.same_process_as_parent
 
         Span.new trace_id, span_id, built_name, @start_time, @end_time,
+                 kind: @kind,
                  parent_span_id: parent_span_id,
                  attributes: built_attributes,
                  dropped_attributes_count: dropped_attributes_count,
@@ -357,6 +385,7 @@ module OpenCensus
         @context = span_context
         @sampled = sampled
         @name = ""
+        @kind = SPAN_KIND_UNSPECIFIED
         @start_time = nil
         @end_time = nil
         @attributes = {}

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -167,19 +167,21 @@ module OpenCensus
       # However, you are responsible for finishing the span yourself.
       #
       # @param [String] name Name of the span
+      # @param [Symbol] kind Kind of span. Defaults to unspecified.
       # @param [Sampler] sampler Span-scoped sampler. If not provided,
       #     defaults to the trace configuration's default sampler.
       #
       # @return [SpanBuilder] A SpanBuilder object that you can use to
       #     set span attributes and create children.
       #
-      def start_span name, skip_frames: 0, sampler: nil
+      def start_span name, kind: nil, skip_frames: 0, sampler: nil
         child_context = create_child
         sampler ||= OpenCensus::Trace.config.default_sampler
         sampled = sampler.call span_context: self
         span = SpanBuilder.new child_context, sampled,
                                skip_frames: skip_frames + 1
         span.name = name
+        span.kind = kind if kind
         span.start!
         @trace_data.span_map[child_context.span_id] = span
       end
@@ -194,11 +196,13 @@ module OpenCensus
       # be finished automatically at the end of the block.
       #
       # @param [String] name Name of the span
+      # @param [Symbol] kind Kind of span. Defaults to unspecified.
       # @param [Sampler] sampler Span-scoped sampler. If not provided,
       #     defaults to the trace configuration's default sampler.
       #
-      def in_span name, skip_frames: 0, sampler: nil
-        span = start_span name, skip_frames: skip_frames + 1, sampler: sampler
+      def in_span name, kind: nil, skip_frames: 0, sampler: nil
+        span = start_span name, kind: kind, skip_frames: skip_frames + 1,
+                                sampler: sampler
         begin
           yield span
         ensure

--- a/test/trace/exporters/logger_test.rb
+++ b/test/trace/exporters/logger_test.rb
@@ -48,7 +48,7 @@ describe OpenCensus::Trace::Exporters::Logger do
     let(:root_context) { OpenCensus::Trace::SpanContext.create_root }
     let(:span1) do
       root_context
-        .start_span("hello")
+        .start_span("hello", kind: OpenCensus::Trace::SpanBuilder::SERVER)
         .put_attribute("foo", "bar")
         .put_annotation("some annotation", {"key" => "value"})
         .put_message_event(OpenCensus::Trace::SpanBuilder::SENT, 1234, 2345)
@@ -68,6 +68,11 @@ describe OpenCensus::Trace::Exporters::Logger do
     it "should serialize name" do
       output["name"].wont_be_empty
       output["name"].must_equal "hello"
+    end
+
+    it "should serialize kind" do
+      output["kind"].wont_be_empty
+      output["kind"].must_equal "SERVER"
     end
 
     it "should serialize attributes" do

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -123,6 +123,7 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       middleware.call env
       span = root_context.build_contained_spans.first
 
+      span.kind.must_equal :CLIENT
       span.status.wont_be_nil
       span.status.code.must_equal 200
       span.attributes["/http/method"].value.must_equal "POST"

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -74,6 +74,7 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
     end
 
     it "adds attributes to the span" do
+      root_span.kind.must_equal :SERVER
       root_span.attributes["/http/method"].value.must_equal "GET"
       root_span.attributes["/http/url"].value.must_equal "https://www.google.com/hello/world"
       root_span.attributes["/http/host"].value.must_equal "www.google.com"

--- a/test/trace/span_builder_test.rb
+++ b/test/trace/span_builder_test.rb
@@ -31,6 +31,23 @@ describe OpenCensus::Trace::SpanBuilder do
     end
   end
 
+  describe "kind" do
+    it "should default to unspecified" do
+      span_builder.kind.must_equal :SPAN_KIND_UNSPECIFIED
+    end
+
+    it "should be settable" do
+      span_builder.kind = :SERVER
+      span_builder.kind.must_equal :SERVER
+    end
+
+    it "should be captured" do
+      span_builder.kind = :CLIENT
+      span = span_builder.to_span
+      span.kind.must_equal :CLIENT
+    end
+  end
+
   describe "parent_span_id" do
     it "should be empty for root span" do
       span_builder.parent_span_id.must_be_empty


### PR DESCRIPTION
Add `kind` field to the span model. Set up rack and faraday middleware to populate the field.

Fixes https://github.com/census-instrumentation/opencensus-ruby/issues/58
