### PR TITLE
Release version 0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,8 @@
 /.bundle/
-/.yardoc
-/Gemfile.lock
-/_yardoc/
-/coverage/
-/doc/
+/.yardoc/
+/docs/
+/examples/*/Gemfile.lock
 /pkg/
-/spec/reports/
 /tmp/
 
-/docs/_site
-/docs/Gemfile.lock
-/docs/api/
-
-/examples/*/Gemfile.lock
+/Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 before_install: gem install bundler -v 1.16.1
 script:
   - bundle exec rake

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--no-private
+--title=OpenCensus
+--markup markdown
+./lib/**/*.rb
+-
+README.md
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### 0.3.1 / 2018-04-13
+
+* Clean unneeded files from the gem
+
 ### 0.3.0 / 2018-03-26
 
 * SpanContext#build_contained_spans honors sampling bit.

--- a/lib/opencensus/version.rb
+++ b/lib/opencensus/version.rb
@@ -14,5 +14,5 @@
 
 module OpenCensus
   ## Current OpenCensus version
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1".freeze
 end

--- a/opencensus.gemspec
+++ b/opencensus.gemspec
@@ -4,23 +4,20 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "opencensus/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "opencensus"
-  spec.version       = OpenCensus::VERSION
-  spec.authors       = ["Jeff Ching", "Daniel Azuma"]
-  spec.email         = ["chingor@google.com", "dazuma@google.com"]
+  spec.name        = "opencensus"
+  spec.version     = OpenCensus::VERSION
+  spec.authors     = ["Jeff Ching", "Daniel Azuma"]
+  spec.email       = ["chingor@google.com", "dazuma@google.com"]
 
-  spec.summary       = %q{A stats collection and distributed tracing framework}
-  spec.description   = %q{A stats collection and distributed tracing framework}
-  spec.homepage      = "https://github.com/census-instrumentation/opencensus-ruby"
-  spec.license       = "Apache-2.0"
+  spec.summary     = "A stats collection and distributed tracing framework"
+  spec.description = "A stats collection and distributed tracing framework"
+  spec.homepage    = "https://github.com/census-instrumentation/opencensus-ruby"
+  spec.license     = "Apache-2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = ::Dir.glob("lib/**/*.rb") +
+               ::Dir.glob("*.md") +
+               ["AUTHORS", "LICENSE", ".yardopts"]
   spec.require_paths = ["lib"]
-
   spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
* Updated travis config to test against latest ruby patches
* Provide yardopts config so rubydoc.info builds docs correctly.
* Update gemspec to whitelist included files—cleans out a bunch of unneeded files.
* Update changelog
