### PR TITLE
Pass sampler to RackMiddleware

### DIFF
--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -51,9 +51,10 @@ module OpenCensus
         #     at the end of the request. Optional: If omitted, uses the exporter
         #     in the current config.
         #
-        def initialize app, exporter: nil
+        def initialize app, exporter: nil, sampler: nil
           @app = app
           @exporter = exporter || OpenCensus::Trace.config.exporter
+          @sampler = sampler || OpenCensus::Trace.config.default_sampler
         end
 
         ##
@@ -76,7 +77,7 @@ module OpenCensus
             trace_context: context,
             same_process_as_parent: false do |span_context|
             begin
-              span_context.in_span get_path(env) do |span|
+              span_context.in_span get_path(env), sampler: @sampler do |span|
                 start_request span, env
                 @app.call(env).tap do |response|
                   finish_request span, response

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -50,6 +50,9 @@ module OpenCensus
         # @param [#export] exporter The exported used to export captured spans
         #     at the end of the request. Optional: If omitted, uses the exporter
         #     in the current config.
+        # @param [#sampler] sampler The sampler used to determine which spans
+        #     get captured. Optional: If omitted, uses the default sampler
+        #     in the current config.
         #
         def initialize app, exporter: nil, sampler: nil
           @app = app

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -123,6 +123,35 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
         spans.count.must_equal 1
       end
     end
+
+    describe "default sampler" do
+      let(:middleware) { OpenCensus::Trace::Integrations::RackMiddleware.new app, exporter: exporter }
+
+      it "should use the default AlwaysSample sampler" do
+        env = {
+          "SCRIPT_NAME" => "",
+          "PATH_INFO" => "/hello/world"
+        }
+        middleware.call env
+        spans = exporter.spans
+        spans.wont_be_empty
+      end
+    end
+
+    describe "custom sampler" do
+      let(:middleware) { OpenCensus::Trace::Integrations::RackMiddleware.new app, exporter: exporter, sampler: OpenCensus::Trace::Samplers::NeverSample.new }
+
+      it "should use the new sampler provided" do
+        env = {
+          "SCRIPT_NAME" => "",
+          "PATH_INFO" => "/hello/world"
+        }
+        middleware.call env
+
+        spans = exporter.spans
+        spans.must_be_empty
+      end
+    end
   end
 
   describe "trace context formatting" do


### PR DESCRIPTION
In addition to the exporter, it would be nice if RackMiddleware would also allow for a different sampler to be passed in order to allow for different sampling strategies for different types of requests.