### PR TITLE
Follow updating TraceContext propagation header specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+### Unreleased
+
+* Use "transparent" in HTTP Header key with the TraceContext.
+
 ### 0.3.1 / 2018-04-13
 
 * Clean unneeded files from the gem

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -77,7 +77,7 @@ module OpenCensus
       # Starts tracing a request in the current thread, by creating a new
       # SpanContext and setting it as the current thread-local context.
       # Generally you should call this when beginning the handling of a
-      # request. If there is a rack environment or a provided Trace-Context
+      # request. If there is a rack environment or a provided Trace-Parent
       # header, pass it in so the SpanContext is constructed accordingly.
       #
       # If you pass a block, this method will yield the SpanContext to the

--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -77,7 +77,7 @@ module OpenCensus
       # Starts tracing a request in the current thread, by creating a new
       # SpanContext and setting it as the current thread-local context.
       # Generally you should call this when beginning the handling of a
-      # request. If there is a rack environment or a provided Trace-Parent
+      # request. If there is a rack environment or a provided traceparent
       # header, pass it in so the SpanContext is constructed accordingly.
       #
       # If you pass a block, this method will yield the SpanContext to the

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -41,7 +41,7 @@ module OpenCensus
         #
         # @private
         #
-        HEADER_NAME = "Trace-Parent".freeze
+        HEADER_NAME = "traceparent".freeze
 
         ##
         # The rack environment header used for the TraceContext header
@@ -49,7 +49,7 @@ module OpenCensus
         #
         # @private
         #
-        RACK_HEADER_NAME = "HTTP_TRACE_PARENT".freeze
+        RACK_HEADER_NAME = "HTTP_TRACEPARENT".freeze
 
         ##
         # Returns the name of the header used for context propagation.

--- a/lib/opencensus/trace/formatters/trace_context.rb
+++ b/lib/opencensus/trace/formatters/trace_context.rb
@@ -41,7 +41,7 @@ module OpenCensus
         #
         # @private
         #
-        HEADER_NAME = "Trace-Context".freeze
+        HEADER_NAME = "Trace-Parent".freeze
 
         ##
         # The rack environment header used for the TraceContext header
@@ -49,7 +49,7 @@ module OpenCensus
         #
         # @private
         #
-        RACK_HEADER_NAME = "HTTP_TRACE_CONTEXT".freeze
+        RACK_HEADER_NAME = "HTTP_TRACE_PARENT".freeze
 
         ##
         # Returns the name of the header used for context propagation.

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -43,9 +43,9 @@ module OpenCensus
 
       class << self
         ##
-        # Create a new root SpanContext object, given either a Trace-Context
+        # Create a new root SpanContext object, given either a Trace-Parent
         # header value by itself, or an entire Rack environment. If a valid
-        # Trace-Context header can be obtained from either source, it is used
+        # Trace-Parent header can be obtained from either source, it is used
         # to generate the SpanContext. Otherwise, a new root context with a
         # unique `trace_id` and a root `span_id` of "" is used.
         #

--- a/lib/opencensus/trace/span_context.rb
+++ b/lib/opencensus/trace/span_context.rb
@@ -43,9 +43,9 @@ module OpenCensus
 
       class << self
         ##
-        # Create a new root SpanContext object, given either a Trace-Parent
+        # Create a new root SpanContext object, given either a traceparent
         # header value by itself, or an entire Rack environment. If a valid
-        # Trace-Parent header can be obtained from either source, it is used
+        # traceparent header can be obtained from either source, it is used
         # to generate the SpanContext. Otherwise, a new root context with a
         # unique `trace_id` and a root `span_id` of "" is used.
         #

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -157,7 +157,7 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       middleware.call env
       span = root_context.build_contained_spans.first
 
-      header = env[:request_headers]["Trace-Context"]
+      header = env[:request_headers]["Trace-Parent"]
       header.must_match %r{^00-#{span.trace_id}-#{span.span_id}}
     end
 

--- a/test/trace/integrations/faraday_middleware_test.rb
+++ b/test/trace/integrations/faraday_middleware_test.rb
@@ -157,7 +157,7 @@ describe OpenCensus::Trace::Integrations::FaradayMiddleware do
       middleware.call env
       span = root_context.build_contained_spans.first
 
-      header = env[:request_headers]["Trace-Parent"]
+      header = env[:request_headers]["traceparent"]
       header.must_match %r{^00-#{span.trace_id}-#{span.span_id}}
     end
 

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -129,7 +129,7 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
     let(:middleware) { OpenCensus::Trace::Integrations::RackMiddleware.new app, exporter: exporter }
     it "parses trace-context header from rack environment" do
       env = {
-        "HTTP_TRACE_CONTEXT" =>
+        "HTTP_TRACE_PARENT" =>
           "00-0123456789ABCDEF0123456789abcdef-0123456789ABCdef-01"
       }
       resp = middleware.call env

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -129,7 +129,7 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
     let(:middleware) { OpenCensus::Trace::Integrations::RackMiddleware.new app, exporter: exporter }
     it "parses trace-context header from rack environment" do
       env = {
-        "HTTP_TRACE_PARENT" =>
+        "HTTP_TRACEPARENT" =>
           "00-0123456789ABCDEF0123456789abcdef-0123456789ABCdef-01"
       }
       resp = middleware.call env


### PR DESCRIPTION
Hi,

According to [the TraceContext specification](https://github.com/w3c/distributed-tracing/blob/7e7e7dfa8f621c86619966be497662f4a76a3598/trace_context/HTTP_HEADER_FORMAT.md), it should use `traceparent` in HTTP request header when propagating context.

This PR is that follow updating specification.
I changed to use`traceparent` instead of `Trace-Context`.