### PR TITLE
Fix rack url scheme

### DIFF
--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -103,7 +103,7 @@ module OpenCensus
         def get_url env
           path = get_path env
           host = get_host env
-          scheme = env["SERVER_PROTOCOL"]
+          scheme = env["rack.url_scheme"]
           query_string = env["QUERY_STRING"].to_s
           url = "#{scheme}://#{host}#{path}"
           url = "#{url}?#{query_string}" unless query_string.empty?

--- a/test/trace/integrations/rack_middleware_test.rb
+++ b/test/trace/integrations/rack_middleware_test.rb
@@ -48,7 +48,8 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
         "PATH_INFO" => "/hello/world",
         "HTTP_HOST" => "www.google.com",
         "REQUEST_METHOD" => "GET",
-        "SERVER_PROTOCOL" => "https",
+        "rack.url_scheme" => "https",
+        "SERVER_PROTOCOL" => "HTTP/1.1",
         "HTTP_USER_AGENT" => "Google Chrome",
       }
       middleware.call env
@@ -78,7 +79,7 @@ describe OpenCensus::Trace::Integrations::RackMiddleware do
       root_span.attributes["/http/method"].value.must_equal "GET"
       root_span.attributes["/http/url"].value.must_equal "https://www.google.com/hello/world"
       root_span.attributes["/http/host"].value.must_equal "www.google.com"
-      root_span.attributes["/http/client_protocol"].value.must_equal "https"
+      root_span.attributes["/http/client_protocol"].value.must_equal "HTTP/1.1"
       root_span.attributes["/http/user_agent"].value.must_equal "Google Chrome"
       root_span.attributes["/pid"].value.wont_be_empty
       root_span.attributes["/tid"].value.wont_be_empty


### PR DESCRIPTION
This fixes the `http/url` key. In rack env, `SERVER_PROTOCOL` corresponds to the http protocol version, e.g. `HTTP/1.1`. Thus, it currently produces an URL that looks like: `HTTP/1.1://example.org/foo`.

The scheme (`http` or `https`) is contained in the rack env under `rack.url_scheme`.