### PR TITLE
Fix require missing in trace

### DIFF
--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "opencensus/context"
 require "opencensus/trace/annotation"
 require "opencensus/trace/config"
 require "opencensus/trace/exporters"

--- a/lib/opencensus/trace/config.rb
+++ b/lib/opencensus/trace/config.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "opencensus/config"
 require "opencensus/trace/exporters"
 require "opencensus/trace/formatters"
 require "opencensus/trace/samplers"


### PR DESCRIPTION
Without these, we can't directly(`require "opencensus/trace"` instead of `require "opencensus"`) use `OpenCensus::Trace`, which dependents on `OpenCensus::Context` and `OpenCensus::Trace::Config`. And `OpenCensus::Trace::Config` dependents on `"opencensus/config"`