### PR TITLE
Support better trace methods when block not given

### DIFF
--- a/lib/opencensus/trace.rb
+++ b/lib/opencensus/trace.rb
@@ -103,6 +103,8 @@ module OpenCensus
           ensure
             unset_span_context
           end
+        else
+          span_context
         end
       end
 


### PR DESCRIPTION
Return span_context and span when block is not given, so that we can use these two methods better.