### PR TITLE
Proper usage of status code

### DIFF
--- a/lib/opencensus/trace/integrations/faraday_middleware.rb
+++ b/lib/opencensus/trace/integrations/faraday_middleware.rb
@@ -172,7 +172,7 @@ module OpenCensus
         def finish_request span, env
           status = env[:status].to_i
           if status > 0
-            span.set_status status
+            span.set_http_status status
             span.put_attribute "/rpc/status_code", status
           end
           body = env[:body]

--- a/lib/opencensus/trace/integrations/rack_middleware.rb
+++ b/lib/opencensus/trace/integrations/rack_middleware.rb
@@ -123,7 +123,7 @@ module OpenCensus
 
         def finish_request span, response
           if response.is_a?(::Array) && response.size == 3
-            span.set_status response[0]
+            span.set_http_status response[0]
           end
         end
       end

--- a/lib/opencensus/trace/span_builder.rb
+++ b/lib/opencensus/trace/span_builder.rb
@@ -276,6 +276,16 @@ module OpenCensus
       end
 
       ##
+      # Set the optional final status for the span using an http status code.
+      #
+      # @param [Integer] code HTTP status code as a 32-bit signed integer
+      # @param [String] message A developer-facing error message, which should
+      #     be in English.
+      def set_http_status code, message = ""
+        set_status map_http_status(code), message
+      end
+
+      ##
       # Set the stack trace for this span.
       # You may call this in one of three ways:
       #
@@ -599,6 +609,23 @@ module OpenCensus
             tstr.force_encoding Encoding::UTF_8
           end
           tstr
+        end
+      end
+
+      private
+
+      def map_http_status http_status
+        case http_status
+        when 200..399 then Status::OK
+        when 400 then Status::INVALID_ARGUMENT
+        when 401 then Status::UNAUTHENTICATED
+        when 403 then Status::PERMISSION_DENIED
+        when 404 then Status::NOT_FOUND
+        when 429 then Status::RESOURCE_EXHAUSTED
+        when 501 then Status::UNIMPLEMENTED
+        when 503 then Status::UNAVAILABLE
+        when 504 then Status::DEADLINE_EXCEEDED
+        else Status::UNKNOWN
         end
       end
     end

--- a/lib/opencensus/trace/status.rb
+++ b/lib/opencensus/trace/status.rb
@@ -17,12 +17,233 @@ module OpenCensus
     ##
     # The `Status` type defines a logical error model that is suitable for
     # different programming environments, including REST APIs and RPC APIs.
-    # This Trace's fields are a subset of those of
-    # [google.rpc.Status](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.Trace),
-    # which is used by [gRPC](https://github.com/grpc).
+    #
     class Status
       ##
-      # The status code.
+      # Not an error; returned on success
+      #
+      # HTTP Mapping: 200 OK
+      #
+      # @return [Integer]
+      #
+      OK = 0
+
+      ##
+      # The operation was cancelled, typically by the caller.
+      #
+      # HTTP Mapping: 499 Client Closed Request
+      #
+      # @return [Integer]
+      #
+      CANCELLED = 1
+
+      ##
+      # Unknown error.  For example, this error may be returned when
+      # a `Status` value received from another address space belongs to
+      # an error space that is not known in this address space.  Also
+      # errors raised by APIs that do not return enough error information
+      # may be converted to this error.
+      #
+      # HTTP Mapping: 500 Internal Server Error
+      #
+      # @return [Integer]
+      #
+      UNKNOWN = 2
+
+      ##
+      # The client specified an invalid argument.  Note that this differs
+      # from `FAILED_PRECONDITION`.  `INVALID_ARGUMENT` indicates arguments
+      # that are problematic regardless of the state of the system
+      # (e.g., a malformed file name).
+      #
+      # HTTP Mapping: 400 Bad Request
+      #
+      # @return [Integer]
+      #
+      INVALID_ARGUMENT = 3
+
+      ##
+      # The deadline expired before the operation could complete. For operations
+      # that change the state of the system, this error may be returned
+      # even if the operation has completed successfully.  For example, a
+      # successful response from a server could have been delayed long
+      # enough for the deadline to expire.
+      #
+      # HTTP Mapping: 504 Gateway Timeout
+      #
+      # @return [Integer]
+      #
+      DEADLINE_EXCEEDED = 4
+
+      ##
+      # Some requested entity (e.g., file or directory) was not found.
+      #
+      # Note to server developers: if a request is denied for an entire class
+      # of users, such as gradual feature rollout or undocumented whitelist,
+      # `NOT_FOUND` may be used. If a request is denied for some users within
+      # a class of users, such as user-based access control, `PERMISSION_DENIED`
+      # must be used.
+      #
+      # HTTP Mapping: 404 Not Found
+      #
+      # @return [Integer]
+      #
+      NOT_FOUND = 5
+
+      ##
+      # The entity that a client attempted to create (e.g., file or directory)
+      # already exists.
+      #
+      # HTTP Mapping: 409 Conflict
+      #
+      # @return [Integer]
+      #
+      ALREADY_EXISTS = 6
+
+      ##
+      # The caller does not have permission to execute the specified
+      # operation. `PERMISSION_DENIED` must not be used for rejections
+      # caused by exhausting some resource (use `RESOURCE_EXHAUSTED`
+      # instead for those errors). `PERMISSION_DENIED` must not be
+      # used if the caller can not be identified (use `UNAUTHENTICATED`
+      # instead for those errors). This error code does not imply the
+      # request is valid or the requested entity exists or satisfies
+      # other pre-conditions.
+      #
+      # HTTP Mapping: 403 Forbidden
+      #
+      # @return [Integer]
+      #
+      PERMISSION_DENIED = 7
+
+      ##
+      # Some resource has been exhausted, perhaps a per-user quota, or
+      # perhaps the entire file system is out of space.
+      #
+      # HTTP Mapping: 429 Too Many Requests
+      #
+      # @return [Integer]
+      #
+      RESOURCE_EXHAUSTED = 8
+
+      ##
+      # The operation was rejected because the system is not in a state
+      # required for the operation's execution.  For example, the directory
+      # to be deleted is non-empty, an rmdir operation is applied to
+      # a non-directory, etc.
+      #
+      # Service implementors can use the following guidelines to decide
+      # between `FAILED_PRECONDITION`, `ABORTED`, and `UNAVAILABLE`:
+      #   a. Use `UNAVAILABLE` if the client can retry just the failing call.
+      #   b. Use `ABORTED` if the client should retry at a higher level
+      #      (e.g., when a client-specified test-and-set fails, indicating the
+      #      client should restart a read-modify-write sequence).
+      #   c. Use `FAILED_PRECONDITION` if the client should not retry until
+      #      the system state has been explicitly fixed.  E.g., if an "rmdir"
+      #      fails because the directory is non-empty, `FAILED_PRECONDITION`
+      #      should be returned since the client should not retry unless
+      #      the files are deleted from the directory.
+      #
+      # HTTP Mapping: 400 Bad Request
+      #
+      # @return [Integer]
+      #
+      FAILED_PRECONDITION = 9
+
+      ##
+      # The operation was aborted, typically due to a concurrency issue such as
+      # a sequencer check failure or transaction abort.
+      #
+      # See the guidelines above for deciding between `FAILED_PRECONDITION`,
+      # `ABORTED`, and `UNAVAILABLE`.
+      #
+      # HTTP Mapping: 409 Conflict
+      #
+      # @return [Integer]
+      #
+      ABORTED = 10
+
+      ##
+      # The operation was attempted past the valid range.  E.g., seeking or
+      # reading past end-of-file.
+      #
+      # Unlike `INVALID_ARGUMENT`, this error indicates a problem that may
+      # be fixed if the system state changes. For example, a 32-bit file
+      # system will generate `INVALID_ARGUMENT` if asked to read at an
+      # offset that is not in the range [0,2^32-1], but it will generate
+      # `OUT_OF_RANGE` if asked to read from an offset past the current
+      # file size.
+      #
+      # There is a fair bit of overlap between `FAILED_PRECONDITION` and
+      # `OUT_OF_RANGE`.  We recommend using `OUT_OF_RANGE` (the more specific
+      # error) when it applies so that callers who are iterating through
+      # a space can easily look for an `OUT_OF_RANGE` error to detect when
+      # they are done.
+      #
+      # HTTP Mapping: 400 Bad Request
+      #
+      # @return [Integer]
+      #
+      OUT_OF_RANGE = 11
+
+      ##
+      # The operation is not implemented or is not supported/enabled in this
+      # service.
+      #
+      # HTTP Mapping: 501 Not Implemented
+      #
+      # @return [Integer]
+      #
+      UNIMPLEMENTED = 12
+
+      ##
+      # Internal errors.  This means that some invariants expected by the
+      # underlying system have been broken.  This error code is reserved
+      # for serious errors.
+      #
+      # HTTP Mapping: 500 Internal Server Error
+      #
+      # @return [Integer]
+      #
+      INTERNAL = 13
+
+      ##
+      # The service is currently unavailable.  This is most likely a
+      # transient condition, which can be corrected by retrying with
+      # a backoff.
+      #
+      # See the guidelines above for deciding between `FAILED_PRECONDITION`,
+      # `ABORTED`, and `UNAVAILABLE`.
+      #
+      # HTTP Mapping: 503 Service Unavailable
+      #
+      # @return [Integer]
+      #
+      UNAVAILABLE = 14
+
+      ##
+      # Unrecoverable data loss or corruption.
+      #
+      # HTTP Mapping: 500 Internal Server Error
+      #
+      # @return [Integer]
+      #
+      DATA_LOSS = 15
+
+      ##
+      # The request does not have valid authentication credentials for the
+      # operation.
+      #
+      # HTTP Mapping: 401 Unauthorized
+      #
+      # @return [Integer]
+      #
+      UNAUTHENTICATED = 16
+
+      ##
+      # The status code. Allowed values are the Google RPC status codes
+      # defined at https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+      # and also provided as constants in this class.
       #
       # @return [Integer]
       #
@@ -36,7 +257,7 @@ module OpenCensus
       attr_reader :message
 
       ##
-      # Create an empty Status object.
+      # Create a Status object.
       #
       # @private
       #

--- a/test/trace/exporters/logger_test.rb
+++ b/test/trace/exporters/logger_test.rb
@@ -53,7 +53,7 @@ describe OpenCensus::Trace::Exporters::Logger do
         .put_annotation("some annotation", {"key" => "value"})
         .put_message_event(OpenCensus::Trace::SpanBuilder::SENT, 1234, 2345)
         .put_link("traceid", "spanid", OpenCensus::Trace::SpanBuilder::CHILD_LINKED_SPAN, {"key2" => "value2"})
-        .set_status(200, "OK")
+        .set_http_status(200, "OK")
         .update_stack_trace
         .finish!
     end

--- a/test/trace/span_builder_test.rb
+++ b/test/trace/span_builder_test.rb
@@ -153,7 +153,7 @@ describe OpenCensus::Trace::SpanBuilder do
   end
 
   describe "set_status" do
-    let(:ret) { span_builder.set_status(200, "OK") }
+    let(:ret) { span_builder.set_status(0, "OK") }
 
     it "should be chainable" do
       ret.must_be_instance_of OpenCensus::Trace::SpanBuilder
@@ -164,8 +164,43 @@ describe OpenCensus::Trace::SpanBuilder do
       span = ret.to_span
       span.status.wont_be_nil
       status = span.status
-      status.code.must_equal 200
+      status.code.must_equal 0
       status.message.must_equal "OK"
+    end
+  end
+
+  describe "set_http_status" do
+    it "should be chainable" do
+      ret = span_builder.set_http_status(200, "OK")
+      ret.must_be_instance_of OpenCensus::Trace::SpanBuilder
+      ret.must_be_same_as span_builder
+    end
+
+    it "should capture 200" do
+      ret = span_builder.set_http_status(200, "OK")
+      span = ret.to_span
+      span.status.wont_be_nil
+      status = span.status
+      status.code.must_equal OpenCensus::Trace::Status::OK
+      status.message.must_equal "OK"
+    end
+
+    it "should capture 404" do
+      ret = span_builder.set_http_status(404, "Not found")
+      span = ret.to_span
+      span.status.wont_be_nil
+      status = span.status
+      status.code.must_equal OpenCensus::Trace::Status::NOT_FOUND
+      status.message.must_equal "Not found"
+    end
+
+    it "should capture 500" do
+      ret = span_builder.set_http_status(500, "Unknown error")
+      span = ret.to_span
+      span.status.wont_be_nil
+      status = span.status
+      status.code.must_equal OpenCensus::Trace::Status::UNKNOWN
+      status.message.must_equal "Unknown error"
     end
   end
 


### PR DESCRIPTION
Previously we were misinterpreting the status code as being equivalent to HTTP status. In fact, it is defined as an rpc status code matching the status values defined in the google.rpc.code proto. This PR:
* Documents what the status code means
* Provides documented constants for the defined codes
* Provides an alternate `set_http_status` method for setting an http status code (which it then maps to rpc status using the [spec](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md#mapping-from-http-status-codes-to-trace-status-codes))
* Updates the rack and faraday middlewares to use `set_http_status` properly
* Updates tests accordingly