### PR TITLE
Tests: Increase timeout for rails server to start

### DIFF
--- a/test/trace/integrations/rails_integration_test.rb
+++ b/test/trace/integrations/rails_integration_test.rb
@@ -86,7 +86,7 @@ describe "Rails integration" do
         end
       end
 
-      def capture_in_rails_context cmd, timeout: 5
+      def capture_in_rails_context cmd, timeout: 6
         result = nil
         Dir.chdir APP_DIR do
           Bundler.with_original_env do


### PR DESCRIPTION
It seems like rails is taking longer to start on Ruby 2.6, so I increase the timeout in the test to help things start up