### PR TITLE
Fix Logger exporter stacktrace

### DIFF
--- a/lib/opencensus/trace/exporters/logger.rb
+++ b/lib/opencensus/trace/exporters/logger.rb
@@ -63,7 +63,7 @@ module OpenCensus
             end_time: span.end_time,
             attributes: format_attributes(span.attributes),
             dropped_attributes_count: span.dropped_attributes_count,
-            stack_trace: span.stack_trace,
+            stack_trace: span.stack_trace.map(&:to_s),
             dropped_frames_count: span.dropped_frames_count,
             stack_trace_hash_id: span.stack_trace_hash_id,
             time_events: span.time_events.map { |te| format_time_event(te) },

--- a/test/trace/exporters/logger_test.rb
+++ b/test/trace/exporters/logger_test.rb
@@ -126,6 +126,7 @@ describe OpenCensus::Trace::Exporters::Logger do
     it "should serialize stack trace" do
       output["stack_trace"].wont_be_empty
       output["stack_trace"].must_be_kind_of Array
+      output["stack_trace"].first.must_be_kind_of String
     end
   end
 end


### PR DESCRIPTION
Fixes #120 
This was necessary because using Rails, Array#to_json was rendering stack traces as [{},{},{},{},{},...]